### PR TITLE
Add dummy input handler

### DIFF
--- a/src/later_posix.cpp
+++ b/src/later_posix.cpp
@@ -12,6 +12,9 @@
 
 using namespace Rcpp;
 
+#define LATER_ACTIVITY 20
+#define LATER_DUMMY_ACTIVITY 21
+
 extern void* R_GlobalContext;
 extern void* R_TopLevelContext;
 
@@ -24,6 +27,8 @@ int initialized = 0;
 // to signal R's input handler callback mechanism that we want to be
 // called back.
 int pipe_in, pipe_out;
+
+int dummy_pipe_in, dummy_pipe_out;
 
 // Whether the file descriptor is ready for reading, i.e., whether
 // the input handler callback is scheduled to be called. We use this
@@ -100,6 +105,14 @@ static void async_input_handler(void *data) {
 }
 
 InputHandler* inputHandlerHandle;
+InputHandler* dummyInputHandlerHandle;
+
+// If the real input handler has been removed, the dummy input handler removes
+// itself. The real input handler cannot remove both; otherwise a segfault
+// could occur.
+static void remove_dummy_handler(void *data) {
+  removeInputHandler(&R_InputHandlers, dummyInputHandlerHandle);
+}
 
 void ensureInitialized() {
   if (!initialized) {
@@ -114,8 +127,20 @@ void ensureInitialized() {
     pipe_out = pipes[0];
     pipe_in = pipes[1];
     
-    inputHandlerHandle = addInputHandler(R_InputHandlers, pipe_out, async_input_handler, 20);
-    
+    inputHandlerHandle = addInputHandler(R_InputHandlers, pipe_out, async_input_handler, LATER_ACTIVITY);
+
+    // Need to add a dummy input handler to avoid segfault when the "real"
+    // input handler removes the subsequent input handler in the linked list.
+    // See https://github.com/rstudio/httpuv/issues/78
+    int dummy_pipes[2];
+    if (pipe(dummy_pipes)) {
+      Rf_error("Failed to create pipe");
+      return;
+    }
+    dummy_pipe_out = dummy_pipes[0];
+    dummy_pipe_in  = dummy_pipes[1];
+    dummyInputHandlerHandle = addInputHandler(R_InputHandlers, dummy_pipe_out, remove_dummy_handler, LATER_DUMMY_ACTIVITY);
+
     initialized = 1;
   }
 }
@@ -124,6 +149,9 @@ void deInitialize() {
   if (initialized) {
     removeInputHandler(&R_InputHandlers, inputHandlerHandle);
     initialized = 0;
+
+    // Trigger remove_dummy_handler()
+    write(dummy_pipe_in, "a", 1);
   }
 }
 

--- a/src/later_posix.cpp
+++ b/src/later_posix.cpp
@@ -112,6 +112,8 @@ InputHandler* dummyInputHandlerHandle;
 // could occur.
 static void remove_dummy_handler(void *data) {
   removeInputHandler(&R_InputHandlers, dummyInputHandlerHandle);
+  close(dummy_pipe_in);
+  close(dummy_pipe_out);
 }
 
 void ensureInitialized() {
@@ -148,6 +150,8 @@ void ensureInitialized() {
 void deInitialize() {
   if (initialized) {
     removeInputHandler(&R_InputHandlers, inputHandlerHandle);
+    close(pipe_in);
+    close(pipe_out);
     initialized = 0;
 
     // Trigger remove_dummy_handler()


### PR DESCRIPTION
This fixes rstudio/httpuv#78. The following no longer triggers the segfault on a mac:

```R
library(httpuv)
library(later)
server <- startDaemonizedServer('127.0.0.1', 8080L, list())
later::later(function() { stopDaemonizedServer(server); cat("server stopped\n") }, 1)
```

It adds a dummy input handler immediately after the real input handler. This is what I did to make sure the dummy handler is getting removed properly:

```
R --debugger=lldb
run --quiet
library(httpuv)
library(later)
server <- startDaemonizedServer('127.0.0.1', 8080L, list())
later::later(function() { stopDaemonizedServer(server); cat("server stopped\n") }, 1)
# Wait for message

<CTRL-C>

# View input handlers: real and dummy handlers are present
ta v *R_InputHandlers
ta v *R_InputHandlers->next
ta v *R_InputHandlers->next->next

# Remove later's real input handler
expr -- (void)deInitialize()

# View input handlers: only dummy handler is present
ta v *R_InputHandlers
ta v *R_InputHandlers->next

# Continue, to allow dummy input handler to remove self
c

<CTRL-C>

# View input handlers: dummy handler is gone
ta v *R_InputHandlers
ta v *R_InputHandlers->next
```

The output from running the commands above:

```
$ R --debugger=lldb
*** Further command line arguments ('--no-save --no-restore-data --quiet ') disregarded
*** (maybe use 'run --no-save --no-restore-data --quiet ' from *inside* lldb)

(lldb) target create "/Library/Frameworks/R.framework/Resources/bin/exec/R"
Current executable set to '/Library/Frameworks/R.framework/Resources/bin/exec/R' (x86_64).
(lldb) run --quiet
Process 22791 launched: '/Library/Frameworks/R.framework/Resources/bin/exec/R' (x86_64)
library(httpuv)
library(later)
server <- startDaemonizedServer('127.0.0.1', 8080L, list())
later::later(function() { stopDaemonizedServer(server); cat("server stopped\n") }, 1)
> library(httpuv)
> library(later)
> server <- startDaemonizedServer('127.0.0.1', 8080L, list())
) }, 1)::later(function() { stopDaemonizedServer(server); cat("server stopped\n" 
> server stopped
Process 22791 stopped
* thread #1, queue = 'com.apple.main-thread', stop reason = signal SIGSTOP
    frame #0: 0x00007fffbdbcdeb6 libsystem_kernel.dylib`__select + 10
libsystem_kernel.dylib`__select:
->  0x7fffbdbcdeb6 <+10>: jae    0x7fffbdbcdec0            ; <+20>
    0x7fffbdbcdeb8 <+12>: movq   %rax, %rdi
    0x7fffbdbcdebb <+15>: jmp    0x7fffbdbc6cd4            ; cerror
    0x7fffbdbcdec0 <+20>: retq   
(lldb) ta v *R_InputHandlers
(InputHandler) *R_InputHandlers = {
  activity = 2
  fileDescriptor = 0
  handler = 0x0000000000000000
  next = 0x0000000103cc0880
  active = 0
  userData = 0x0000000000000000
}
(lldb) ta v *R_InputHandlers->next
(_InputHandler) *R_InputHandlers->next = {
  activity = 20
  fileDescriptor = 3
  handler = 0x0000000103fe0ac0 (later.so`async_input_handler(void*) at later_posix.cpp:80)
  next = 0x0000000103c02de0
  active = 0
  userData = 0x0000000000000000
}
(lldb) ta v *R_InputHandlers->next->next
(_InputHandler) *R_InputHandlers->next->next = {
  activity = 21
  fileDescriptor = 5
  handler = 0x0000000103fe0c80 (later.so`remove_dummy_handler(void*) at later_posix.cpp:113)
  next = 0x0000000000000000
  active = 0
  userData = 0x0000000000000000
}
(lldb) expr -- (void)deInitialize()
(lldb) ta v *R_InputHandlers
(InputHandler) *R_InputHandlers = {
  activity = 2
  fileDescriptor = 0
  handler = 0x0000000000000000
  next = 0x0000000103c02de0
  active = 0
  userData = 0x0000000000000000
}
(lldb) ta v *R_InputHandlers->next
(_InputHandler) *R_InputHandlers->next = {
  activity = 21
  fileDescriptor = 5
  handler = 0x0000000103fe0c80 (later.so`remove_dummy_handler(void*) at later_posix.cpp:113)
  next = 0x0000000000000000
  active = 0
  userData = 0x0000000000000000
}
(lldb) c
Process 22791 resuming
Process 22791 stopped
* thread #1, queue = 'com.apple.main-thread', stop reason = signal SIGSTOP
    frame #0: 0x00007fffbdbcdeb6 libsystem_kernel.dylib`__select + 10
libsystem_kernel.dylib`__select:
->  0x7fffbdbcdeb6 <+10>: jae    0x7fffbdbcdec0            ; <+20>
    0x7fffbdbcdeb8 <+12>: movq   %rax, %rdi
    0x7fffbdbcdebb <+15>: jmp    0x7fffbdbc6cd4            ; cerror
    0x7fffbdbcdec0 <+20>: retq   
(lldb) ta v *R_InputHandlers
(InputHandler) *R_InputHandlers = {
  activity = 2
  fileDescriptor = 0
  handler = 0x0000000000000000
  next = 0x0000000000000000
  active = 0
  userData = 0x0000000000000000
}
(lldb) ta v *R_InputHandlers->next
(_InputHandler) *R_InputHandlers->next = <parent is NULL>
```