### PR TITLE
Fix hang on install under Fedora 25+

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: later
 Type: Package
 Title: Utilities for Delaying Function Execution
-Version: 0.4
+Version: 0.4.0.9000
 Authors@R: c(
     person("Joe", "Cheng", role = c("aut", "cre"), email = "joe@rstudio.com"),
     person(family = "RStudio", role = "cph"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 ## later 0.5
 
-* Fix a hang on Fedora 25+ which prevented the package from being installed successfully.
+* Fix a hang on Fedora 25+ which prevented the package from being installed successfully. Reported by @lepennec. [Issue #7](https://github.com/r-lib/later/issues/7), [PR #10](https://github.com/r-lib/later/pull/10)
 
 ## later 0.4
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## later 0.5
+
+* Fix a hang on Fedora 25+ which prevented the package from being installed successfully.
+
 ## later 0.4
 
 * Add `loop_empty()` function, which returns `TRUE` if there are currently no callbacks that are scheduled to execute in the present or future.

--- a/R/later.R
+++ b/R/later.R
@@ -75,20 +75,20 @@ later <- function(func, delay = 0) {
 }
 
 #' Execute scheduled operations
-#' 
+#'
 #' Normally, operations scheduled with [later()] will not execute unless/until
 #' no other R code is on the stack (i.e. at the top-level). If you need to run
 #' blocking R code for a long time and want to allow scheduled operations to run
 #' at well-defined points of your own operation, you can call `run_now()` at
 #' those points and any operations that are due to run will do so.
-#' 
+#'
 #' If one of the callbacks throws an error, the error will _not_ be caught, and
 #' subsequent callbacks will not be executed (until `run_now()` is called again,
-#' or control returns to the R prompt). You must use your own [base::tryCatch()]
-#' if you want to handle errors.
-#' 
+#' or control returns to the R prompt). You must use your own
+#' [tryCatch][base::conditions] if you want to handle errors.
+#'
 #' @return A logical indicating whether any callbacks were actually run.
-#' 
+#'
 #' @export
 run_now <- function() {
   invisible(execCallbacks())

--- a/man/run_now.Rd
+++ b/man/run_now.Rd
@@ -19,6 +19,6 @@ those points and any operations that are due to run will do so.
 \details{
 If one of the callbacks throws an error, the error will \emph{not} be caught, and
 subsequent callbacks will not be executed (until \code{run_now()} is called again,
-or control returns to the R prompt). You must use your own \code{\link[base:tryCatch]{base::tryCatch()}}
-if you want to handle errors.
+or control returns to the R prompt). You must use your own
+\link[base:conditions]{tryCatch} if you want to handle errors.
 }

--- a/src/timer_posix.h
+++ b/src/timer_posix.h
@@ -12,7 +12,9 @@ class Timer {
   boost::function<void ()> callback;
   pthread_mutex_t mutex;
   pthread_cond_t cond;
+  pthread_t bgthread;
   boost::optional<Timestamp> wakeAt;
+  bool stopped;
   
   static void* bg_main_func(void*);
   void bg_main();


### PR DESCRIPTION
This was due to the destructor of the timing loop calling `pthread_cond_destroy` on a condition variable that was still being waited on. I fixed this by signaling the thread to end itself, then waiting on the thread before proceeding.