### PR TITLE
Use Rcpp macros to properly handle exceptions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * Fix a hang on Fedora 25+ which prevented the package from being installed successfully. Reported by @lepennec. [Issue #7](https://github.com/r-lib/later/issues/7), [PR #10](https://github.com/r-lib/later/pull/10)
 
+* Fixed [issue #12](https://github.com/r-lib/later/issues/12): When an exception occurred in a callback function, it would cause future callbacks to not execute. [PR #13](https://github.com/r-lib/later/pull/13)
+
 ## later 0.4
 
 * Add `loop_empty()` function, which returns `TRUE` if there are currently no callbacks that are scheduled to execute in the present or future.

--- a/src/callback_registry.h
+++ b/src/callback_registry.h
@@ -24,14 +24,7 @@ public:
   }
   
   void operator()() const {
-    // From example in http://gallery.rcpp.org/articles/intro-to-exceptions/
-    try {
-      func();
-    } catch(std::exception &ex) {	
-      forward_exception_to_r(ex);
-    } catch(...) { 
-      ::Rf_error("c++ exception (unknown reason)"); 
-    }
+    func();
   }
 
   Timestamp when;

--- a/src/later_posix.cpp
+++ b/src/later_posix.cpp
@@ -78,6 +78,11 @@ public:
 };
 
 static void async_input_handler(void *data) {
+  // The BEGIN_RCPP and VOID_END_RCPP macros are needed so that, if an exception
+  // occurs in any of the callbacks, destructors will still execute.
+  // https://github.com/r-lib/later/issues/12
+  // https://github.com/RcppCore/Rcpp/issues/753
+  BEGIN_RCPP
   if (!at_top_level()) {
     // It's not safe to run arbitrary callbacks when other R code
     // is already running. Wait until we're back at the top level.
@@ -102,6 +107,7 @@ static void async_input_handler(void *data) {
   SuspendFDReadiness sfdr_scope;
   
   execCallbacks();
+  VOID_END_RCPP
 }
 
 InputHandler* inputHandlerHandle;

--- a/src/later_win32.cpp
+++ b/src/later_win32.cpp
@@ -32,6 +32,11 @@ static void setupTimer() {
 }
 
 static bool executeHandlers() {
+  // The BEGIN_RCPP and END_RCPP macros are needed so that, if an exception
+  // occurs in any of the callbacks, destructors will still execute.
+  // https://github.com/r-lib/later/issues/12
+  // https://github.com/RcppCore/Rcpp/issues/753
+  BEGIN_RCPP
   if (!at_top_level()) {
     // It's not safe to run arbitrary callbacks when other R code
     // is already running. Wait until we're back at the top level.
@@ -40,6 +45,7 @@ static bool executeHandlers() {
 
   execCallbacks();  
   return idle();
+  END_RCPP
 }
 
 LRESULT CALLBACK callbackWndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam) {


### PR DESCRIPTION
This fixes #12. If a `stop()` occurs in a callback, it no longer breaks `later()`.

Note that quitting the debugger still causes problems, but that might not be fixable, according to the discussion on the related Rcpp issue.