### PR TITLE
Fix #16: Hang on ASAN builds of R

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: later
 Type: Package
 Title: Utilities for Delaying Function Execution
-Version: 0.5
+Version: 0.5.0.9000
 Authors@R: c(
     person("Joe", "Cheng", role = c("aut", "cre"), email = "joe@rstudio.com"),
     person(family = "RStudio", role = "cph"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## later 0.6
+
+* Fix a hang on address sanitized (ASAN) builds of R. [Issue #16](https://github.com/r-lib/later/issues/16), [PR #17](https://github.com/r-lib/later/pull/17)
+
 ## later 0.5
 
 * Fix a hang on Fedora 25+ which prevented the package from being installed successfully. Reported by @lepennec. [Issue #7](https://github.com/r-lib/later/issues/7), [PR #10](https://github.com/r-lib/later/pull/10)

--- a/src/timer_posix.cpp
+++ b/src/timer_posix.cpp
@@ -13,48 +13,50 @@ void* Timer::bg_main_func(void* data) {
 void Timer::bg_main() {
   pthread_mutex_lock(&this->mutex);
   while (true) {
-    if (this->wakeAt == boost::none) {
-      // The wake time has not been set yet. Wait until it is set, then start
-      // the loop over again, so we hit the other branch.
+    
+    // Guarded wait; we can't pass here until either the timer is stopped or we
+    // have a wait time.
+    while (!(this->stopped || this->wakeAt != boost::none)) {
       pthread_cond_wait(&this->cond, &this->mutex);
+    }
+    
+    // We're stopped; return, which ends the thread.
+    if (this->stopped) {
+      return;
+    }
+    
+    // The wake time has been set. There are three possibilities:
+    // 1. The wake time is in the past. Go ahead and execute now.
+    // 2. Wait for the wake time, but we're notified before time elapses.
+    //    Start the loop again.
+    // 3. Wait for the wake time, and time elapses. Go ahead and execute now.
+    double secs = (*this->wakeAt).diff_secs(Timestamp());
+    if (secs > 0) {
+      // Sadly, the pthread_cond_timedwait API requires an absolute time, not
+      // a relative time. gettimeofday is the only way to do this that works
+      // on both Linux and Darwin.
+      timeval tv;
+      timespec ts;
+      gettimeofday(&tv, NULL);
+      TIMEVAL_TO_TIMESPEC(&tv, &ts);
+      ts.tv_sec += (time_t)secs;
+      ts.tv_nsec += (secs - (time_t)secs) * 1e9;
+      if (ts.tv_nsec < 0) {
+        ts.tv_nsec += 1e9;
+        ts.tv_sec--;
+      }
+      if (ts.tv_nsec > 1e9) {
+        ts.tv_nsec -= 1e9;
+        ts.tv_sec++;
+      }
+
+      int res = pthread_cond_timedwait(&this->cond, &this->mutex, &ts);
       if (this->stopped) {
         return;
       }
-      continue;
-    } else {
-      // The wake time has been set. There are three possibilities:
-      // 1. The wake time is in the past. Go ahead and execute now.
-      // 2. Wait for the wake time, but we're notified before time elapses.
-      //    Start the loop again.
-      // 3. Wait for the wake time, and time elapses. Go ahead and execute now.
-      double secs = (*this->wakeAt).diff_secs(Timestamp());
-      if (secs > 0) {
-        // Sadly, the pthread_cond_timedwait API requires an absolute time, not
-        // a relative time. gettimeofday is the only way to do this that works
-        // on both Linux and Darwin.
-        timeval tv;
-        timespec ts;
-        gettimeofday(&tv, NULL);
-        TIMEVAL_TO_TIMESPEC(&tv, &ts);
-        ts.tv_sec += (time_t)secs;
-        ts.tv_nsec += (secs - (time_t)secs) * 1e9;
-        if (ts.tv_nsec < 0) {
-          ts.tv_nsec += 1e9;
-          ts.tv_sec--;
-        }
-        if (ts.tv_nsec > 1e9) {
-          ts.tv_nsec -= 1e9;
-          ts.tv_sec++;
-        }
-
-        int res = pthread_cond_timedwait(&this->cond, &this->mutex, &ts);
-        if (this->stopped) {
-          return;
-        }
-        if (ETIMEDOUT != res) {
-          // Time didn't elapse, we were woken up (probably). Start over.
-          continue;
-        }
+      if (ETIMEDOUT != res) {
+        // Time didn't elapse, we were woken up (probably). Start over.
+        continue;
       }
     }
 
@@ -68,8 +70,6 @@ Timer::Timer(const boost::function<void ()>& callback) :
   
   pthread_mutex_init(&this->mutex, NULL);
   pthread_cond_init(&this->cond, NULL);
-  
-  pthread_create(&this->bgthread, NULL, &bg_main_func, this);
 }
 
 Timer::~Timer() {
@@ -77,12 +77,14 @@ Timer::~Timer() {
   // Must stop background thread before cleaning up condition variable and
   // mutex. Calling pthread_cond_destroy on a condvar that's being waited
   // on results in undefined behavior--on Fedora 25+ it hangs.
-  pthread_mutex_lock(&this->mutex);
-  this->stopped = true;
-  pthread_cond_signal(&this->cond);
-  pthread_mutex_unlock(&this->mutex);
-
-  pthread_join(this->bgthread, NULL);
+  if (this->bgthread != boost::none) {
+    pthread_mutex_lock(&this->mutex);
+    this->stopped = true;
+    pthread_cond_signal(&this->cond);
+    pthread_mutex_unlock(&this->mutex);
+  
+    pthread_join(*this->bgthread, NULL);
+  }
 
   pthread_cond_destroy(&this->cond);
   pthread_mutex_destroy(&this->mutex);
@@ -90,6 +92,13 @@ Timer::~Timer() {
 
 void Timer::set(const Timestamp& timestamp) {
   pthread_mutex_lock(&this->mutex);
+  
+  // If the thread has not yet been created, created it.
+  if (this->bgthread == boost::none) {
+    pthread_t thread;
+    pthread_create(&thread, NULL, &bg_main_func, this);
+    this->bgthread = thread;
+  }
   
   this->wakeAt = timestamp;
   pthread_cond_signal(&this->cond);

--- a/src/timer_posix.h
+++ b/src/timer_posix.h
@@ -12,7 +12,10 @@ class Timer {
   boost::function<void ()> callback;
   pthread_mutex_t mutex;
   pthread_cond_t cond;
-  pthread_t bgthread;
+  // Stores the handle to a bgthread, which is created upon demand. (Previously
+  // the thread was created in the constructor, but addressed sanitized (ASAN)
+  // builds of R would hang when pthread_create was called during dlopen.)
+  boost::optional<pthread_t> bgthread;
   boost::optional<Timestamp> wakeAt;
   bool stopped;
   


### PR DESCRIPTION
Apparently due to trying to call pthread_create during dlopen.
The fix is to create the thread on demand instead of during
initialization.