### PR TITLE
Tweak run_now() behavior to discourage running forever

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: later
 Type: Package
 Title: Utilities for Delaying Function Execution
-Version: 0.5.0.9000
+Version: 0.5.0.9001
 Authors@R: c(
     person("Joe", "Cheng", role = c("aut", "cre"), email = "joe@rstudio.com"),
     person(family = "RStudio", role = "cph"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 * Fix a hang on address sanitized (ASAN) builds of R. [Issue #16](https://github.com/r-lib/later/issues/16), [PR #17](https://github.com/r-lib/later/pull/17)
 
-* The `run_now()` function used to return only when it was unable to find any more tasks that were due. This means that if tasks were being scheduled at an interval faster than the tasks are executed, `run_now()` would never return. This release changes that behavior so that a timestamp is taken as `run_now()` begins executing, and only tasks whose timestamps are earlier or equal to it are run.
+* The `run_now()` function used to return only when it was unable to find any more tasks that were due. This means that if tasks were being scheduled at an interval faster than the tasks are executed, `run_now()` would never return. This release changes that behavior so that a timestamp is taken as `run_now()` begins executing, and only tasks whose timestamps are earlier or equal to it are run. [PR #18](https://github.com/r-lib/later/pull/18)
 
 ## later 0.5
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * Fix a hang on address sanitized (ASAN) builds of R. [Issue #16](https://github.com/r-lib/later/issues/16), [PR #17](https://github.com/r-lib/later/pull/17)
 
+* The `run_now()` function used to return only when it was unable to find any more tasks that were due. This means that if tasks were being scheduled at an interval faster than the tasks are executed, `run_now()` would never return. This release changes that behavior so that a timestamp is taken as `run_now()` begins executing, and only tasks whose timestamps are earlier or equal to it are run.
+
 ## later 0.5
 
 * Fix a hang on Fedora 25+ which prevented the package from being installed successfully. Reported by @lepennec. [Issue #7](https://github.com/r-lib/later/issues/7), [PR #10](https://github.com/r-lib/later/pull/10)

--- a/src/callback_registry.cpp
+++ b/src/callback_registry.cpp
@@ -34,15 +34,15 @@ bool CallbackRegistry::empty() const {
 }
 
 // Returns true if the smallest timestamp exists and is not in the future.
-bool CallbackRegistry::due() const {
+bool CallbackRegistry::due(const Timestamp& time) const {
   Guard guard(mutex);
-  return !this->queue.empty() && !this->queue.top().when.future();
+  return !this->queue.empty() && !(this->queue.top().when > time);
 }
 
-std::vector<Callback> CallbackRegistry::take(size_t max) {
+std::vector<Callback> CallbackRegistry::take(size_t max, const Timestamp& time) {
   Guard guard(mutex);
   std::vector<Callback> results;
-  while (this->due() && (max <= 0 || results.size() < max)) {
+  while (this->due(time) && (max <= 0 || results.size() < max)) {
     results.push_back(this->queue.top());
     this->queue.pop();
   }

--- a/src/callback_registry.h
+++ b/src/callback_registry.h
@@ -56,10 +56,10 @@ public:
   bool empty() const;
   
   // Is anything ready to execute?
-  bool due() const;
+  bool due(const Timestamp& time = Timestamp()) const;
   
   // Pop and return an ordered list of functions to execute now.
-  std::vector<Callback> take(size_t max = -1);
+  std::vector<Callback> take(size_t max = -1, const Timestamp& time = Timestamp());
 };
 
 #endif // _CALLBACK_REGISTRY_H_

--- a/src/later.cpp
+++ b/src/later.cpp
@@ -55,11 +55,12 @@ bool execCallbacks() {
   Rcpp::RNGScope rngscope;
   ProtectCallbacks pcscope;
   
+  Timestamp now;
   bool any = false;
   while (true) {
     // We only take one at a time, because we don't want to lose callbacks if 
     // one of the callbacks throws an error
-    std::vector<Callback> callbacks = callbackRegistry.take(1);
+    std::vector<Callback> callbacks = callbackRegistry.take(1, now);
     if (callbacks.size() == 0) {
       break;
     }


### PR DESCRIPTION
Repro (warning, running this on master branch will hang your R session):

```r
local({
  run <- function() {
    later::later(run, 0.001)
    Sys.sleep(0.001)
  }
  later::later(run, 0)
  later::run_now()
})
```
