### PR TITLE
Catch exceptions when executing from input handler

### DIFF
--- a/src/later_win32.cpp
+++ b/src/later_win32.cpp
@@ -32,18 +32,37 @@ static void setupTimer() {
 }
 
 static bool executeHandlers() {
-  // The BEGIN_RCPP and END_RCPP macros are needed so that, if an exception
-  // occurs in any of the callbacks, destructors will still execute.
-  // https://github.com/r-lib/later/issues/12
-  // https://github.com/RcppCore/Rcpp/issues/753
-  BEGIN_RCPP
   if (!at_top_level()) {
     // It's not safe to run arbitrary callbacks when other R code
     // is already running. Wait until we're back at the top level.
     return false;
   }
 
-  execCallbacks();  
+  // This try-catch is meant to be similar to the BEGIN_RCPP and VOID_END_RCPP
+  // macros. They are needed for two reasons: first, if an exception occurs in
+  // any of the callbacks, destructors will still execute; and second, if an
+  // exception (including R-level error) occurs in a callback and it reaches
+  // the top level in an R input handler, R appears to be unable to handle it
+  // properly.
+  // https://github.com/r-lib/later/issues/12
+  // https://github.com/RcppCore/Rcpp/issues/753
+  // https://github.com/r-lib/later/issues/31
+  try {
+    execCallbacks();
+  }
+  catch(Rcpp::internal::InterruptedException &e) {
+    REprintf("later: interrupt occurred while executing callback.");
+  }
+  catch(std::exception& e){
+    std::string msg = "later: exception occurred while executing callback: \n";
+    msg += e.what();
+    msg += "\n";
+    REprintf(msg.c_str());
+  }
+  catch( ... ){
+    REprintf("later: c++ exception (unknown reason) occurred while executing callback.");
+  }
+
   return idle();
   END_RCPP
 }


### PR DESCRIPTION
Fixes #31, fixes #29, fixes #25.

This is what it looks like now when an error occurs in a callback run by the input handler:

```
> library(later)
> later(function() stop("an error here"))
> later: exception occurred while executing callback: 
Evaluation error: an error here.
```


Compare to when it's run by `run_now()`:

```
> {
+     later(function() stop("an error here"))
+     run_now()
+ }
Error in execCallbacks(timeoutSecs) : Evaluation error: an error here.
```

Additionally, the terminal no longer gets messed up when an error occurs in the input handler.

I think it makes sense to simply swallow the exceptions and not try to call `stop()` or `Rf_error()`, which is what the `END_RCPP` macro essentially does.