### PR TITLE
Allow scheduling boost::function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: later
 Type: Package
 Title: Utilities for Delaying Function Execution
-Version: 0.7.1
+Version: 0.7.1.9000
 Authors@R: c(
     person("Joe", "Cheng", role = c("aut", "cre"), email = "joe@rstudio.com"),
     person(family = "RStudio", role = "cph"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## later 0.7.1.9000
+
+* With the C++ interface for `later::later()`, it is now possible to schedule a `boost::function<void(void)>` for execution. [PR #41](https://github.com/r-lib/later/pull/41)
+
 ## later 0.7.1
 
 * Fixed [issue #39](https://github.com/r-lib/later/issues/39): Calling the C++ function `later::later()` from a different thread could cause an R GC event to occur on that thread, leading to memory corruption. [PR #40](https://github.com/r-lib/later/pull/40)

--- a/src/callback_registry.cpp
+++ b/src/callback_registry.cpp
@@ -14,6 +14,14 @@ void CallbackRegistry::add(Rcpp::Function func, double secs) {
   condvar.signal();
 }
 
+void CallbackRegistry::add(boost::function<void(void)> func, double secs) {
+  Timestamp when(secs);
+  Callback_sp cb = boost::make_shared<Callback>(when, func);
+  Guard guard(mutex);
+  queue.push(cb);
+  condvar.signal();
+}
+
 void CallbackRegistry::add(void (*func)(void*), void* data, double secs) {
   Timestamp when(secs);
   Callback_sp cb = boost::make_shared<Callback>(when, boost::bind(func, data));

--- a/src/callback_registry.h
+++ b/src/callback_registry.h
@@ -58,9 +58,13 @@ private:
 public:
   CallbackRegistry();
 
-  // Add a function to the registry, to be executed at `secs` seconds in
+  // Add an R function to the registry, to be executed at `secs` seconds in
   // the future (i.e. relative to the current time).
   void add(Rcpp::Function func, double secs);
+
+  // Add a boost::function to the registry, to be executed at `secs` seconds
+  // in the future (i.e. relative to the current time).
+  void add(boost::function<void(void)> func, double secs);
   
   // Add a C function to the registry, to be executed at `secs` seconds in
   // the future (i.e. relative to the current time).


### PR DESCRIPTION
This makes it simpler to schedule functions like the ones mentioned here:
  https://github.com/rstudio/httpuv/pull/106#pullrequestreview-90663726

@jcheng5, before merging, we should discuss the object lifetime issues that came up in an earlier conversation. I don't think that they will be a problem here.

I think we avoided adding this in the past because of concerns that it would introduce a boost dependency, but I don't think that this PR is actually adding such a dependency.