### PR TITLE
Fix clang-UBSAN issue about wrong function pointer type

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: later
 Type: Package
 Title: Utilities for Delaying Function Execution
-Version: 0.7.1
+Version: 0.7.1.1
 Authors@R: c(
     person("Joe", "Cheng", role = c("aut", "cre"), email = "joe@rstudio.com"),
     person(family = "RStudio", role = "cph"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,8 @@
-## later 0.7.1
+## later 0.7.1.1
+
+* Fix incorrect language linkage for internal function type, causing problems for checks under UBSAN builds of R.
+
+## later 0.7.1 (unreleased)
 
 * Fixed [issue #39](https://github.com/r-lib/later/issues/39): Calling the C++ function `later::later()` from a different thread could cause an R GC event to occur on that thread, leading to memory corruption. [PR #40](https://github.com/r-lib/later/pull/40)
 

--- a/inst/include/later.h
+++ b/inst/include/later.h
@@ -17,6 +17,11 @@
 
 namespace later {
 
+namespace {
+// The function type for the real execLaterNative
+extern "C" typedef void (*elnfun)(void (*func)(void*), void*, double);
+}
+
 inline void later(void (*func)(void*), void* data, double secs) {
   // This function works by retrieving the later::execLaterNative function
   // pointer using R_GetCCallable the first time it's called (per compilation
@@ -33,8 +38,6 @@ inline void later(void (*func)(void*), void* data, double secs) {
   // specially by including them in RcppExports.cpp, and we definitely
   // do not want the static initialization to happen there.
   
-  // The function type for the real execLaterNative
-  typedef void (*elnfun)(void (*func)(void*), void*, double);
   static elnfun eln = NULL;
   if (!eln) {
     // Initialize if necessary


### PR DESCRIPTION
Intended to fix this clang-UBSAN issue:

```
/data/gannet/ripley/R/packages/tests-clang-SAN/later.Rcheck/later/include/later.h:57:3: runtime error: call to function execLaterNative through pointer to incorrect function type 'void (*)(void (*)(void *), void *, double)'
/data/gannet/ripley/R/packages/tests-clang-SAN/later/src/later.cpp:107: note: execLaterNative defined here
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /data/gannet/ripley/R/packages/tests-clang-SAN/later.Rcheck/later/include/later.h:57:3 in 
/data/gannet/ripley/R/test-clang/BH/include/boost/bind/bind.hpp:259:9: runtime error: call to function later::BackgroundTask::result_callback(void*) through pointer to incorrect function type 'void (*)(void *)'
/data/gannet/ripley/R/packages/tests-clang-SAN/later.Rcheck/later/include/later.h:116: note: later::BackgroundTask::result_callback(void*) defined here
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /data/gannet/ripley/R/test-clang/BH/include/boost/bind/bind.hpp:259:9 in 
```

The function type was `extern "C"` but the function pointer type was default (C++) linkage.