### PR TITLE
Fix #48: Occasional timedwait errors from later::run_now

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## later 0.7.2
+
+* Fixed [issue #48](https://github.com/r-lib/later/issues/48): Occasional timedwait errors from later::run_now. Thanks, @vnijs! [PR #49](https://github.com/r-lib/later/pull/49)
+
 ## later 0.7.1
 
 * Fixed [issue #39](https://github.com/r-lib/later/issues/39): Calling the C++ function `later::later()` from a different thread could cause an R GC event to occur on that thread, leading to memory corruption. [PR #40](https://github.com/r-lib/later/pull/40)

--- a/src/threadutils.h
+++ b/src/threadutils.h
@@ -88,6 +88,9 @@ class ConditionVariable : boost::noncopyable {
   
 public:
   ConditionVariable(Mutex& mutex) : _m(&mutex._m) {
+    if (!std::is_integral<time_t>::value)
+      throw std::runtime_error("Integral time_t type expected");
+    
     if (cnd_init(&_c) != thrd_success)
       throw std::runtime_error("Condition variable failed to initialize");
   }

--- a/src/threadutils.h
+++ b/src/threadutils.h
@@ -122,7 +122,7 @@ public:
       ts.tv_nsec += 1e9;
       ts.tv_sec--;
     }
-    if (ts.tv_nsec > 1e9) {
+    if (ts.tv_nsec >= 1e9) {
       ts.tv_nsec -= 1e9;
       ts.tv_sec++;
     }

--- a/src/threadutils.h
+++ b/src/threadutils.h
@@ -8,6 +8,8 @@ extern "C" {
 }
 #include <boost/noncopyable.hpp>
 
+#include "timeconv.h"
+
 #ifndef CLOCK_REALTIME
 // This is only here to prevent compilation errors on Windows and older
 // versions of OS X. clock_gettime doesn't exist on those platforms so
@@ -116,17 +118,9 @@ public:
     if (clock_gettime(CLOCK_REALTIME, &ts) != 0) {
       throw std::runtime_error("clock_gettime failed");
     }
-    ts.tv_sec += (time_t)timeoutSecs;
-    ts.tv_nsec += (timeoutSecs - (time_t)timeoutSecs) * 1e9;
-    if (ts.tv_nsec < 0) {
-      ts.tv_nsec += 1e9;
-      ts.tv_sec--;
-    }
-    if (ts.tv_nsec >= 1e9) {
-      ts.tv_nsec -= 1e9;
-      ts.tv_sec++;
-    }
     
+    ts = addSeconds(ts, timeoutSecs);
+
     int res = cnd_timedwait(&_c, _m, &ts);
     if (res == thrd_success) {
       return true;

--- a/src/timeconv.h
+++ b/src/timeconv.h
@@ -13,3 +13,18 @@ inline timeval timespecToTimeval(const timespec& ts) {
   tv.tv_usec = ts.tv_nsec / 1000;
   return tv;
 }
+
+inline timespec addSeconds(const timespec& time, double secs) {
+  timespec ts = time;
+  ts.tv_sec += (time_t)secs;
+  ts.tv_nsec += (secs - (time_t)secs) * 1e9;
+  if (ts.tv_nsec < 0) {
+    ts.tv_nsec += 1e9;
+    ts.tv_sec--;
+  }
+  if (ts.tv_nsec >= 1e9) {
+    ts.tv_nsec -= 1e9;
+    ts.tv_sec++;
+  }
+  return ts;
+}

--- a/src/timer_posix.cpp
+++ b/src/timer_posix.cpp
@@ -39,16 +39,7 @@ void Timer::bg_main() {
       timeval tv;
       gettimeofday(&tv, NULL);
       timespec ts = timevalToTimespec(tv);
-      ts.tv_sec += (time_t)secs;
-      ts.tv_nsec += (secs - (time_t)secs) * 1e9;
-      if (ts.tv_nsec < 0) {
-        ts.tv_nsec += 1e9;
-        ts.tv_sec--;
-      }
-      if (ts.tv_nsec >= 1e9) {
-        ts.tv_nsec -= 1e9;
-        ts.tv_sec++;
-      }
+      ts = addSeconds(ts, secs);
 
       int res = pthread_cond_timedwait(&this->cond, &this->mutex, &ts);
       if (this->stopped) {

--- a/src/timer_posix.cpp
+++ b/src/timer_posix.cpp
@@ -45,7 +45,7 @@ void Timer::bg_main() {
         ts.tv_nsec += 1e9;
         ts.tv_sec--;
       }
-      if (ts.tv_nsec > 1e9) {
+      if (ts.tv_nsec >= 1e9) {
         ts.tv_nsec -= 1e9;
         ts.tv_sec++;
       }

--- a/src/timestamp_unix.cpp
+++ b/src/timestamp_unix.cpp
@@ -26,7 +26,7 @@ public:
     long nanos = (secs - wholeSecs) * 1e9;
     this->time.tv_sec += wholeSecs;
     this->time.tv_nsec += nanos;
-    while (this->time.tv_nsec > 1e9) {
+    while (this->time.tv_nsec >= 1e9) {
       this->time.tv_sec++;
       this->time.tv_nsec -= 1e9;
     }

--- a/src/timestamp_unix.cpp
+++ b/src/timestamp_unix.cpp
@@ -22,18 +22,7 @@ public:
   TimestampImplPosix(double secs) {
     get_current_time(&this->time);
     
-    time_t wholeSecs = (long)secs;
-    long nanos = (secs - wholeSecs) * 1e9;
-    this->time.tv_sec += wholeSecs;
-    this->time.tv_nsec += nanos;
-    while (this->time.tv_nsec >= 1e9) {
-      this->time.tv_sec++;
-      this->time.tv_nsec -= 1e9;
-    }
-    while (this->time.tv_nsec < 0) {
-      this->time.tv_sec--;
-      this->time.tv_nsec += 1e9;
-    }
+    this->time = addSeconds(this->time, secs);
   }
   
   virtual bool future() const {

--- a/src/tinycthread.c
+++ b/src/tinycthread.c
@@ -305,10 +305,6 @@ int cnd_timedwait(cnd_t *cond, mtx_t *mtx, const struct timespec *ts)
   {
     return thrd_timeout;
   }
-  else if (ret != 0)
-  {
-    fprintf(stderr, "pthread_cond_timedwait returned %d\n", ret);
-  }
   return ret == 0 ? thrd_success : thrd_error;
 #endif
 }


### PR DESCRIPTION
`pthread_cond_timedwait` takes an absolute time value. Our API takes a timeout duration (e.g. "2 seconds"), not time. So we need to read the current time, and add the specified duration. The data structure used by posix is `timespec` which has separate integral values for second and nanosecond. Our code to deal with overflow (>=1e9 nanoseconds) was erroneous in that in only considered >1e9 to be overflow, not >=1e9. This meant that sometimes we passed a `timespec` whose nanosec field was 1e9, which returned `EINVAL`.