### PR TITLE
Fix build warning on macOS 10.11

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * Fixed [issue #48](https://github.com/r-lib/later/issues/48): Occasional timedwait errors from later::run_now. Thanks, @vnijs! [PR #49](https://github.com/r-lib/later/pull/49)
 
+* Fixed a build warning on OS X 10.11 and earlier. [PR #54](https://github.com/r-lib/later/pull/54)
+
 ## later 0.7.1
 
 * Fixed [issue #39](https://github.com/r-lib/later/issues/39): Calling the C++ function `later::later()` from a different thread could cause an R GC event to occur on that thread, leading to memory corruption. [PR #40](https://github.com/r-lib/later/pull/40)

--- a/src/debug.h
+++ b/src/debug.h
@@ -4,9 +4,7 @@
 // See the Makevars file to see how to compile with various debugging settings.
 
 #if defined(DEBUG_THREAD)
-extern "C" {
 #include "tinycthread.h"
-}
 
 extern thrd_t __main_thread__;
 extern thrd_t __background_thread__;

--- a/src/threadutils.h
+++ b/src/threadutils.h
@@ -3,13 +3,11 @@
 
 #include <stdexcept>
 #include <sys/time.h>
-extern "C" {
-#include "tinycthread.h"
-}
 #include <boost/noncopyable.hpp>
 #include <boost/type_traits/is_integral.hpp>
 #include <boost/type_traits/is_signed.hpp>
 
+#include "tinycthread.h"
 #include "timeconv.h"
 
 #ifndef CLOCK_REALTIME

--- a/src/threadutils.h
+++ b/src/threadutils.h
@@ -8,6 +8,7 @@ extern "C" {
 }
 #include <boost/noncopyable.hpp>
 #include <boost/type_traits/is_integral.hpp>
+#include <boost/type_traits/is_signed.hpp>
 
 #include "timeconv.h"
 
@@ -89,8 +90,14 @@ class ConditionVariable : boost::noncopyable {
   
 public:
   ConditionVariable(Mutex& mutex) : _m(&mutex._m) {
+    // If time_t isn't integral, our addSeconds logic needs to change,
+    // as it relies on casting to time_t being a truncation.
     if (!boost::is_integral<time_t>::value)
       throw std::runtime_error("Integral time_t type expected");
+    // If time_t isn't signed, our addSeconds logic can't handle
+    // negative values for secs.
+    if (!boost::is_signed<time_t>::value)
+      throw std::runtime_error("Signed time_t type expected");
     
     if (cnd_init(&_c) != thrd_success)
       throw std::runtime_error("Condition variable failed to initialize");

--- a/src/timeconv.h
+++ b/src/timeconv.h
@@ -1,4 +1,9 @@
 #include <sys/time.h>
+// Some platforms (Win32, previously some Mac versions) use
+// tinycthread.h to provide timespec. Whether tinycthread
+// defines timespec or not, we want it to be consistent for
+// anyone who uses these functions.
+#include "tinycthread.h"
 
 inline timespec timevalToTimespec(const timeval& tv) {
   timespec ts;

--- a/src/tinycthread.h
+++ b/src/tinycthread.h
@@ -24,6 +24,10 @@ freely, subject to the following restrictions:
 #ifndef _TINYCTHREAD_H_
 #define _TINYCTHREAD_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // jcheng 2017-11-03: _XOPEN_SOURCE 600 is necessary to prevent Solaris headers
 // from complaining about the combination of C99 and _XOPEN_SOURCE <= 500. The
 // error message starts with:
@@ -449,6 +453,10 @@ void *tss_get(tss_t key);
 */
 int tss_set(tss_t key, void *val);
 
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _TINYTHREAD_H_ */
 

--- a/src/tinycthread.h
+++ b/src/tinycthread.h
@@ -112,15 +112,23 @@ freely, subject to the following restrictions:
   #endif
 #endif
 
-/* Workaround for missing clock_gettime (most Windows compilers, and macOS < 10.12 afaik) */
-#if defined(_TTHREAD_WIN32_) || (defined(__APPLE__) && !defined(CLOCK_MONOTONIC))
-#define _TTHREAD_EMULATE_CLOCK_GETTIME_
+// jcheng 2018-04-30: This was in the _TTHREAD_EMULATE_CLOCK_GETTIME_
+// block previously, but all macOS versions provide timespec, and
+// overwriting it with _ttherad_timespec caused compilation errors
+// when trying to call POSIX functions that expected the regular
+// timespec.
+#if defined(_TTHREAD_WIN32_)
 /* Emulate struct timespec */
 struct _ttherad_timespec {
   time_t tv_sec;
   long   tv_nsec;
 };
 #define timespec _ttherad_timespec
+#endif
+
+/* Workaround for missing clock_gettime (most Windows compilers, and macOS < 10.12 afaik) */
+#if defined(_TTHREAD_WIN32_) || (defined(__APPLE__) && !defined(CLOCK_MONOTONIC))
+#define _TTHREAD_EMULATE_CLOCK_GETTIME_
 
 /* Emulate clockid_t */
 typedef int _tthread_clockid_t;


### PR DESCRIPTION
Cannot be tested using `rhub::check_on_macos()` because it acts like 10.12 at build time but 10.11 at runtime (!?).