### PR TITLE
Fix crash when user interrupts sys.nframe()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: later
 Type: Package
 Title: Utilities for Delaying Function Execution
-Version: 0.7.2
+Version: 0.7.2.9000
 Authors@R: c(
     person("Joe", "Cheng", role = c("aut", "cre"), email = "joe@rstudio.com"),
     person(family = "RStudio", role = "cph"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## later 0.7.2.9000
+
+* Fixed [issue #57](https://github.com/r-lib/later/issues/57): If a user interrupt occurred when later (internally) called `sys.nframe()`, the R process would crash. [PR #58](https://github.com/r-lib/later/pull/58)
+
 ## later 0.7.2
 
 * Fixed [issue #48](https://github.com/r-lib/later/issues/48): Occasional timedwait errors from later::run_now. Thanks, @vnijs! [PR #49](https://github.com/r-lib/later/pull/49)


### PR DESCRIPTION
This fixes #57.

It simply attempts to call `sys.nframe()` up to 10 times. I believe that the only reason that the call should error (and thus need to be called again) is if the user happens to interrupt it.