### PR TITLE
Suspend interrupt while running sys.nframe()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: later
 Type: Package
 Title: Utilities for Delaying Function Execution
-Version: 0.7.2.9000
+Version: 0.7.2.9001
 Authors@R: c(
     person("Joe", "Cheng", role = c("aut", "cre"), email = "joe@rstudio.com"),
     person(family = "RStudio", role = "cph"),

--- a/src/interrupt.h
+++ b/src/interrupt.h
@@ -1,0 +1,32 @@
+#ifndef _INTERRUPT_H_
+#define _INTERRUPT_H_
+
+#ifdef _WIN32
+
+#include <windows.h>
+#undef TRUE
+#undef FALSE
+
+#endif // _WIN32
+
+
+// Borrowed from https://github.com/wch/r-source/blob/a0a6b159/src/include/R_ext/GraphicsDevice.h#L843-L858
+#ifndef BEGIN_SUSPEND_INTERRUPTS
+/* Macros for suspending interrupts */
+#define BEGIN_SUSPEND_INTERRUPTS do { \
+    Rboolean __oldsusp__ = R_interrupts_suspended; \
+    R_interrupts_suspended = TRUE;
+#define END_SUSPEND_INTERRUPTS R_interrupts_suspended = __oldsusp__; \
+    if (R_interrupts_pending && ! R_interrupts_suspended) \
+        Rf_onintr(); \
+} while(0)
+
+#include <R_ext/libextern.h>
+LibExtern Rboolean R_interrupts_suspended;
+LibExtern int R_interrupts_pending;
+extern void Rf_onintr(void);
+LibExtern Rboolean mbcslocale;
+#endif
+
+
+#endif


### PR DESCRIPTION
Instead of trying to run `sys.nframe()` repeatedly in case of an error (which includes interrupts), this suspends interrupts while running `sys.nframe()`.

With code borrowed from:
https://github.com/wch/r-source/blob/a0a6b159/src/include/Defn.h#L1438-L1444
https://github.com/wch/r-source/blob/a0a6b159/src/include/R_ext/GraphicsDevice.h#L843-L858
