### PR TITLE
Make sure to compile tinycthread on Windows

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,2 +1,7 @@
+PKG_CPPFLAGS += -DTHREADS_H_SUPPORT=-1
+PKG_LIBS += ./tinycthread/tinycthread.o
+
 # Uncomment to enable thread assertions
 # PKG_CPPFLAGS += -DDEBUG_THREAD -UNDEBUG
+
+$(SHLIB): ./tinycthread/tinycthread.o


### PR DESCRIPTION
In #64, the tinycthread library was moved to a subdirectory. This ensures that it gets compiled on Windows.