### PR TITLE
Fix bug where later causes 100% CPU in R from terminal

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: later
 Type: Package
 Title: Utilities for Delaying Function Execution
-Version: 0.7.5
+Version: 0.7.5.9000
 Authors@R: c(
     person("Joe", "Cheng", role = c("aut", "cre"), email = "joe@rstudio.com"),
     person(family = "RStudio", role = "cph"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## later 0.7.5.9000
+
+* Fixed [issue #74](https://github.com/r-lib/later/issues/74): Using later with R at the terminal on POSIX could cause 100% CPU. This was caused by later accidentally provoking R to call its input handler continuously. [PR #76](https://github.com/r-lib/later/pull/76)
+
 ## later 0.7.5
 
 * Fixed issue where the order of callbacks scheduled by native later::later could be nondeterministic if they are scheduled too quickly. This was because callbacks were sorted by the time at which they come due, which could be identical. Later now uses the order of insertion as a tiebreaker. [PR #69](https://github.com/r-lib/later/pull/69)

--- a/src/later_posix.cpp
+++ b/src/later_posix.cpp
@@ -199,13 +199,13 @@ void doExecLater(Rcpp::Function callback, double delaySecs) {
   ASSERT_MAIN_THREAD()
   callbackRegistry.add(callback, delaySecs);
   
-  timer.set(*callbackRegistry.nextTimestamp());
+  timer.set(*(callbackRegistry.nextTimestamp()));
 }
 
 void doExecLater(void (*callback)(void*), void* data, double delaySecs) {
   callbackRegistry.add(callback, data, delaySecs);
   
-  timer.set(*callbackRegistry.nextTimestamp());
+  timer.set(*(callbackRegistry.nextTimestamp()));
 }
 
 #endif // ifndef _WIN32

--- a/src/later_posix.cpp
+++ b/src/later_posix.cpp
@@ -77,8 +77,10 @@ public:
   ResetTimerOnExit() {
   }
   ~ResetTimerOnExit() {
-    if (!idle()) {
-      timer.set(*callbackRegistry.nextTimestamp());
+    // Find the next event in the registry and, if there is one, set the timer.
+    Optional<Timestamp> nextEvent = callbackRegistry.nextTimestamp();
+    if (nextEvent.has_value()) {
+      timer.set(*nextEvent);
     }
   }
 };


### PR DESCRIPTION
Fixes #74 

### Testing notes

See the repro example in #74, and also https://github.com/rstudio/websocket/issues/34. It must be tested on Mac and Linux; Windows is not affected.