### PR TITLE
Use std::atomic if available

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 * Fixed [issue #74](https://github.com/r-lib/later/issues/74): Using later with R at the terminal on POSIX could cause 100% CPU. This was caused by later accidentally provoking R to call its input handler continuously. [PR #76](https://github.com/r-lib/later/pull/76)
 
+* Fixed [issue #73](https://github.com/r-lib/later/issues/73): Linking later on ARM failed because `boost::atomic` requires the `-lboost_atomic` flag. Now later tries to use `std::atomic` when available (when the compiler supports C++11), and falls back to `boost::atomic` if not. [PR #80](https://github.com/r-lib/later/pull/80)
+
 ## later 0.7.5
 
 * Fixed issue where the order of callbacks scheduled by native later::later could be nondeterministic if they are scheduled too quickly. This was because callbacks were sorted by the time at which they come due, which could be identical. Later now uses the order of insertion as a tiebreaker. [PR #69](https://github.com/r-lib/later/pull/69)

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,3 +1,6 @@
+# Use C++11 if available
+CXX_STD=CXX11
+
 PKG_CPPFLAGS = -pthread
 PKG_LIBS = -pthread
 

--- a/src/callback_registry.cpp
+++ b/src/callback_registry.cpp
@@ -1,4 +1,3 @@
-#include <boost/atomic.hpp>
 #include <boost/bind.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/make_shared.hpp>
@@ -6,7 +5,16 @@
 #include "callback_registry.h"
 #include "debug.h"
 
-boost::atomic<uint64_t> nextCallbackNum(0);
+#if __cplusplus >= 201103L
+  #include <atomic>
+  std::atomic<uint64_t> nextCallbackNum(0);
+#else
+  // Fall back to boost::atomic if std::atomic isn't available. We want to
+  // avoid boost::atomic when possible because on ARM, it requires the
+  // -lboost_atomic linker flag. (https://github.com/r-lib/later/issues/73)
+  #include <boost/atomic.hpp>
+  boost::atomic<uint64_t> nextCallbackNum(0);
+#endif
 
 Callback::Callback(Timestamp when, Task func) : when(when), func(func) {
   this->callbackNum = nextCallbackNum++;


### PR DESCRIPTION
This (should) fix #73 -- assuming that there's a C++11 compiler available on the RPi.

If a C++11 compiler is available, then it uses `std::atomic` instead of `boost::atomic`, and there's no need to link to `boost_atomic`.