### PR TITLE
Implement callback cancellation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: later
 Type: Package
 Title: Utilities for Delaying Function Execution
-Version: 0.8.0.9001
+Version: 0.8.0.9002
 Authors@R: c(
     person("Joe", "Cheng", role = c("aut", "cre"), email = "joe@rstudio.com"),
     person(family = "RStudio", role = "cph"),

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -34,7 +34,11 @@ idle <- function(loop) {
 }
 
 execLater <- function(callback, delaySecs, loop) {
-    invisible(.Call('_later_execLater', PACKAGE = 'later', callback, delaySecs, loop))
+    .Call('_later_execLater', PACKAGE = 'later', callback, delaySecs, loop)
+}
+
+cancel <- function(callback_id_s, loop) {
+    .Call('_later_cancel', PACKAGE = 'later', callback_id_s, loop)
 }
 
 nextOpSecs <- function(loop) {

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -93,15 +93,28 @@ BEGIN_RCPP
 END_RCPP
 }
 // execLater
-void execLater(Rcpp::Function callback, double delaySecs, int loop);
+std::string execLater(Rcpp::Function callback, double delaySecs, int loop);
 RcppExport SEXP _later_execLater(SEXP callbackSEXP, SEXP delaySecsSEXP, SEXP loopSEXP) {
 BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< Rcpp::Function >::type callback(callbackSEXP);
     Rcpp::traits::input_parameter< double >::type delaySecs(delaySecsSEXP);
     Rcpp::traits::input_parameter< int >::type loop(loopSEXP);
-    execLater(callback, delaySecs, loop);
-    return R_NilValue;
+    rcpp_result_gen = Rcpp::wrap(execLater(callback, delaySecs, loop));
+    return rcpp_result_gen;
+END_RCPP
+}
+// cancel
+bool cancel(std::string callback_id_s, int loop);
+RcppExport SEXP _later_cancel(SEXP callback_id_sSEXP, SEXP loopSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< std::string >::type callback_id_s(callback_id_sSEXP);
+    Rcpp::traits::input_parameter< int >::type loop(loopSEXP);
+    rcpp_result_gen = Rcpp::wrap(cancel(callback_id_s, loop));
+    return rcpp_result_gen;
 END_RCPP
 }
 // nextOpSecs

--- a/src/init.c
+++ b/src/init.c
@@ -12,6 +12,7 @@ extern SEXP _later_ensureInitialized();
 extern SEXP _later_execCallbacks(SEXP, SEXP, SEXP);
 extern SEXP _later_idle(SEXP);
 extern SEXP _later_execLater(SEXP, SEXP, SEXP);
+extern SEXP _later_cancel(SEXP, SEXP);
 extern SEXP _later_nextOpSecs(SEXP);
 extern SEXP _later_testCallbackOrdering();
 extern SEXP _later_createCallbackRegistry(SEXP);
@@ -24,6 +25,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"_later_execCallbacks",       (DL_FUNC) &_later_execCallbacks,       3},
   {"_later_idle",                (DL_FUNC) &_later_idle,                1},
   {"_later_execLater",           (DL_FUNC) &_later_execLater,           3},
+  {"_later_cancel",              (DL_FUNC) &_later_cancel,              2},
   {"_later_nextOpSecs",          (DL_FUNC) &_later_nextOpSecs,          1},
   {"_later_testCallbackOrdering", (DL_FUNC) &_later_testCallbackOrdering, 0},
   {"_later_createCallbackRegistry", (DL_FUNC) &_later_createCallbackRegistry, 1},

--- a/src/later.cpp
+++ b/src/later.cpp
@@ -192,6 +192,7 @@ std::string execLater(Rcpp::Function callback, double delaySecs, int loop) {
 
 
 bool cancel(uint64_t callback_id, int loop) {
+  ASSERT_MAIN_THREAD()
   if (!existsCallbackRegistry(loop))
     return false;
 
@@ -204,6 +205,7 @@ bool cancel(uint64_t callback_id, int loop) {
 
 // [[Rcpp::export]]
 bool cancel(std::string callback_id_s, int loop) {
+  ASSERT_MAIN_THREAD()
   uint64_t callback_id;
   std::istringstream iss(callback_id_s);
   iss >> callback_id;

--- a/src/later_posix.cpp
+++ b/src/later_posix.cpp
@@ -193,19 +193,23 @@ void deInitialize() {
   }
 }
 
-void doExecLater(boost::shared_ptr<CallbackRegistry> callbackRegistry, Rcpp::Function callback, double delaySecs, bool resetTimer) {
+uint64_t doExecLater(boost::shared_ptr<CallbackRegistry> callbackRegistry, Rcpp::Function callback, double delaySecs, bool resetTimer) {
   ASSERT_MAIN_THREAD()
-  callbackRegistry->add(callback, delaySecs);
-  
+  uint64_t callback_id = callbackRegistry->add(callback, delaySecs);
+
   if (resetTimer)
     timer.set(*(callbackRegistry->nextTimestamp()));
+
+  return callback_id;
 }
 
-void doExecLater(boost::shared_ptr<CallbackRegistry> callbackRegistry, void (*callback)(void*), void* data, double delaySecs, bool resetTimer) {
-  callbackRegistry->add(callback, data, delaySecs);
+uint64_t doExecLater(boost::shared_ptr<CallbackRegistry> callbackRegistry, void (*callback)(void*), void* data, double delaySecs, bool resetTimer) {
+  uint64_t callback_id = callbackRegistry->add(callback, data, delaySecs);
 
-  if (resetTimer)  
+  if (resetTimer)
     timer.set(*(callbackRegistry->nextTimestamp()));
+
+  return callback_id;
 }
 
 #endif // ifndef _WIN32

--- a/src/later_win32.cpp
+++ b/src/later_win32.cpp
@@ -102,15 +102,17 @@ void ensureInitialized() {
   }
 }
 
-void doExecLater(boost::shared_ptr<CallbackRegistry> callbackRegistry, Rcpp::Function callback, double delaySecs, bool resetTimer) {
-  callbackRegistry->add(callback, delaySecs);
+uint64_t doExecLater(boost::shared_ptr<CallbackRegistry> callbackRegistry, Rcpp::Function callback, double delaySecs, bool resetTimer) {
+  uint64_t callback_id = callbackRegistry->add(callback, delaySecs);
 
-  if (resetTimer)  
+  if (resetTimer)
     setupTimer();
+
+  return callback_id;
 }
 
-void doExecLater(boost::shared_ptr<CallbackRegistry> callbackRegistry, void (*func)(void*), void* data, double delaySecs, bool resetTimer) {
-  callbackRegistry->add(func, data, delaySecs);
+uint64_t doExecLater(boost::shared_ptr<CallbackRegistry> callbackRegistry, void (*func)(void*), void* data, double delaySecs, bool resetTimer) {
+  uint64_t callback_id = callbackRegistry->add(func, data, delaySecs);
 
   if (resetTimer) {
     if (GetCurrentThreadId() == GetWindowThreadProcessId(hwnd, NULL)) {
@@ -121,6 +123,8 @@ void doExecLater(boost::shared_ptr<CallbackRegistry> callbackRegistry, void (*fu
       PostMessage(hwnd, WM_SETUPTIMER, 0, 0);
     }
   }
+
+  return callback_id;
 }
 
 #endif // ifdef _WIN32

--- a/tests/testthat/test-cancel.R
+++ b/tests/testthat/test-cancel.R
@@ -1,0 +1,150 @@
+context("test-cancel.R")
+
+test_that("Cancelling callbacks", {
+  # Cancel with zero delay
+  x <- 0
+  cancel <- later(function() { x <<- x + 1 })
+  later(function() { x <<- x + 2 })
+  expect_true(cancel())
+  run_now()
+  expect_identical(x, 2)
+
+  # Cancel with zero delay
+  x <- 0
+  cancel <- later(function() { x <<- x + 1 }, 1)
+  run_now(0.25)
+  expect_true(cancel())
+  run_now(1)
+  expect_identical(x, 0)
+
+  # Make sure a cancelled callback doesn't interfere with others
+  x <- 0
+  later(function() { x <<- x + 1 }, 1)
+  cancel <- later(function() { x <<- x + 2 }, 0.5)
+  run_now()
+  expect_true(cancel())
+  run_now(2)
+  expect_identical(x, 1)
+})
+
+
+test_that("Cancelled functions will be GC'd", {
+  l <- create_loop(autorun = FALSE)
+  x <- 0
+  cancel <- later(
+    local({
+      reg.finalizer(environment(), function(e) x <<- x + 1)
+      function() message("foo")
+    })
+  )
+  expect_true(cancel())
+  gc()
+  expect_identical(x, 1)
+})
+
+
+test_that("Cancelling executed or cancelled callbacks has no effect", {
+  # Cancelling an executed callback
+  x <- 0
+  cancel <- later(function() { x <<- x + 1 })
+  run_now()
+  expect_false(cancel())
+  run_now()
+  expect_identical(x, 1)
+
+  # Cancelling twice
+  x <- 0
+  cancel <- later(function() { x <<- x + 1 })
+  expect_true(cancel())
+  expect_false(cancel())
+  run_now()
+  expect_identical(x, 0)
+})
+
+
+test_that("Cancelling callbacks on temporary event loops", {
+  with_temp_loop({
+    # Cancelling an executed callback
+    x <- 0
+    cancel <- later(function() { x <<- x + 1 })
+    run_now()
+    expect_false(cancel())
+    run_now()
+    expect_identical(x, 1)
+  })
+
+  with_temp_loop({
+    # Cancelling twice
+    x <- 0
+    cancel <- later(function() { x <<- x + 1 })
+    expect_true(cancel())
+    expect_false(cancel())
+    run_now()
+    expect_identical(x, 0)
+  })
+
+  with_temp_loop({
+    # Make sure a cancelled callback doesn't interfere with others
+    x <- 0
+    later(function() { x <<- x + 1 }, 1)
+    cancel <- later(function() { x <<- x + 2 }, 0.5)
+    run_now()
+    expect_true(cancel())
+    run_now(2)
+    expect_identical(x, 1)
+  })
+
+  # Canceling after an event loop has been destroyed should return FALSE
+  cancel <- NULL
+  x <- 0
+  with_temp_loop({
+    cancel <<- later(function() { x <<- x + 1 })
+  })
+  expect_false(cancel())
+  expect_identical(x, 0)
+})
+
+
+test_that("Cancelling callbacks on persistent private loops", {
+  l1 <- create_loop(autorun = FALSE)
+  l2 <- create_loop(autorun = FALSE)
+
+  # Cancel from outside with_loop
+  cancel <- NULL
+  x <- 0
+  with_loop(l1, {
+    cancel <<- later(function() { x <<- x + 1 })
+  })
+  expect_true(cancel())
+  expect_false(cancel())
+  with_loop(l1, run_now())
+  expect_false(cancel())
+  expect_identical(x, 0)
+
+
+  # Make sure it doesn't interfere with other event loops
+  with_loop(l1, {
+    cancel <<- later(function() { x <<- x + 1 })
+  })
+  with_loop(l2, {
+    later(function() { x <<- x + 2 })
+  })
+  later(function() { x <<- x + 4 })
+  expect_true(cancel())
+  with_loop(l1, run_now())
+  with_loop(l2, run_now())
+  run_now()
+  expect_identical(x, 6)
+
+
+  # Cancelling on an explicitly destroyed loop returns FALSE
+  l3 <- create_loop(autorun = FALSE)
+  cancel <- NULL
+  x <- 0
+  with_loop(l3, {
+    cancel <<- later(function() { x <<- x + 1 })
+  })
+  destroy_loop(l3)
+  expect_false(cancel())
+  expect_identical(x, 0)
+})


### PR DESCRIPTION
This PR adds the ability to cancel callbacks. When `later()` is called, it returns a function which cancels that callback if invoked.

Usage:

```R
cancel <- later(function() message("hello"), 2)
cancel()
```

The canceller function returns `TRUE` if successful, `FALSE` if not (for example, if it has already executed or has been canceled, or if the event loop that it belongs to has been destroyed).