### PR TITLE
Rename thrd_t to tct_thrd_t

### DIFF
--- a/src/debug.h
+++ b/src/debug.h
@@ -6,15 +6,15 @@
 #if defined(DEBUG_THREAD)
 #include "tinycthread.h"
 
-extern thrd_t __main_thread__;
-extern thrd_t __background_thread__;
+extern tct_thrd_t __main_thread__;
+extern tct_thrd_t __background_thread__;
 
 // This must be called from the main thread so that thread assertions can be
 // tested later.
-#define REGISTER_MAIN_THREAD()       __main_thread__ = thrd_current();
-#define REGISTER_BACKGROUND_THREAD() __background_thread__ = thrd_current();
-#define ASSERT_MAIN_THREAD()         assert(thrd_current() == __main_thread__);
-#define ASSERT_BACKGROUND_THREAD()   assert(thrd_current() == __background_thread__);
+#define REGISTER_MAIN_THREAD()       __main_thread__ = tct_thrd_current();
+#define REGISTER_BACKGROUND_THREAD() __background_thread__ = tct_thrd_current();
+#define ASSERT_MAIN_THREAD()         assert(tct_thrd_current() == __main_thread__);
+#define ASSERT_BACKGROUND_THREAD()   assert(tct_thrd_current() == __background_thread__);
 
 #else
 #define REGISTER_MAIN_THREAD()

--- a/src/later.cpp
+++ b/src/later.cpp
@@ -14,7 +14,7 @@
 
 // For debug.h
 #if defined(DEBUG_THREAD)
-thrd_t __main_thread__;
+tct_thrd_t __main_thread__;
 #endif
 
 // Declare platform-specific functions that are implemented in

--- a/src/timer_posix.cpp
+++ b/src/timer_posix.cpp
@@ -72,7 +72,7 @@ void Timer::set(const Timestamp& timestamp) {
 
   // If the thread has not yet been created, created it.
   if (this->bgthread == boost::none) {
-    thrd_t thread;
+    tct_thrd_t thread;
     tct_thrd_create(&thread, &bg_main_func, this);
     this->bgthread = thread;
   }

--- a/src/timer_posix.h
+++ b/src/timer_posix.h
@@ -15,7 +15,7 @@ class Timer {
   // Stores the handle to a bgthread, which is created upon demand. (Previously
   // the thread was created in the constructor, but addressed sanitized (ASAN)
   // builds of R would hang when pthread_create was called during dlopen.)
-  boost::optional<thrd_t> bgthread;
+  boost::optional<tct_thrd_t> bgthread;
   boost::optional<Timestamp> wakeAt;
   bool stopped;
   

--- a/src/tinycthread.c
+++ b/src/tinycthread.c
@@ -589,7 +589,7 @@ static void * _thrd_wrapper_function(void * aArg)
 #endif
 }
 
-int tct_thrd_create(thrd_t *thr, tct_thrd_start_t func, void *arg)
+int tct_thrd_create(tct_thrd_t *thr, tct_thrd_start_t func, void *arg)
 {
   /* Fill out the thread startup information (passed to the thread wrapper,
      which will eventually free it) */
@@ -621,7 +621,7 @@ int tct_thrd_create(thrd_t *thr, tct_thrd_start_t func, void *arg)
   return tct_thrd_success;
 }
 
-thrd_t tct_thrd_current(void)
+tct_thrd_t tct_thrd_current(void)
 {
 #if defined(_TTHREAD_WIN32_)
   return GetCurrentThread();
@@ -630,7 +630,7 @@ thrd_t tct_thrd_current(void)
 #endif
 }
 
-int tct_thrd_detach(thrd_t thr)
+int tct_thrd_detach(tct_thrd_t thr)
 {
 #if defined(_TTHREAD_WIN32_)
   /* https://stackoverflow.com/questions/12744324/how-to-detach-a-thread-on-windows-c#answer-12746081 */
@@ -640,7 +640,7 @@ int tct_thrd_detach(thrd_t thr)
 #endif
 }
 
-int tct_thrd_equal(thrd_t thr0, thrd_t thr1)
+int tct_thrd_equal(tct_thrd_t thr0, tct_thrd_t thr1)
 {
 #if defined(_TTHREAD_WIN32_)
   return GetThreadId(thr0) == GetThreadId(thr1);
@@ -663,7 +663,7 @@ void tct_thrd_exit(int res)
 #endif
 }
 
-int tct_thrd_join(thrd_t thr, int *res)
+int tct_thrd_join(tct_thrd_t thr, int *res)
 {
 #if defined(_TTHREAD_WIN32_)
   DWORD dwRes;

--- a/src/tinycthread.h
+++ b/src/tinycthread.h
@@ -331,9 +331,9 @@ int tct_cnd_timedwait(tct_cnd_t *cond, tct_mtx_t *mtx, const struct timespec *ts
 
 /* Thread */
 #if defined(_TTHREAD_WIN32_)
-typedef HANDLE thrd_t;
+typedef HANDLE tct_thrd_t;
 #else
-typedef pthread_t thrd_t;
+typedef pthread_t tct_thrd_t;
 #endif
 
 /** Thread start function.
@@ -358,24 +358,24 @@ typedef int (*tct_thrd_start_t)(void *arg);
 * original thread has exited and either been detached or joined to another
 * thread.
 */
-int tct_thrd_create(thrd_t *thr, tct_thrd_start_t func, void *arg);
+int tct_thrd_create(tct_thrd_t *thr, tct_thrd_start_t func, void *arg);
 
 /** Identify the calling thread.
 * @return The identifier of the calling thread.
 */
-thrd_t tct_thrd_current(void);
+tct_thrd_t tct_thrd_current(void);
 
 /** Dispose of any resources allocated to the thread when that thread exits.
  * @return thrd_success, or thrd_error on error
 */
-int tct_thrd_detach(thrd_t thr);
+int tct_thrd_detach(tct_thrd_t thr);
 
 /** Compare two thread identifiers.
 * The function determines if two thread identifiers refer to the same thread.
 * @return Zero if the two thread identifiers refer to different threads.
 * Otherwise a nonzero value is returned.
 */
-int tct_thrd_equal(thrd_t thr0, thrd_t thr1);
+int tct_thrd_equal(tct_thrd_t thr0, tct_thrd_t thr1);
 
 /** Terminate execution of the calling thread.
 * @param res Result code of the calling thread.
@@ -391,7 +391,7 @@ TTHREAD_NORETURN void tct_thrd_exit(int res);
 * @return @ref thrd_success on success, or @ref thrd_error if the request could
 * not be honored.
 */
-int tct_thrd_join(thrd_t thr, int *res);
+int tct_thrd_join(tct_thrd_t thr, int *res);
 
 /** Put the calling thread to sleep.
 * Suspend execution of the calling thread.


### PR DESCRIPTION
In #79, we renamed all the objects from tinycthread so that they started with `tct_`. We also added `badthreads.h` to help detect any instances that we missed, however, because `tinycthread.h` includes `badthreads.h` at the top and then later defines `thrd_t`, we didn't detect that we missed renaming this one.

This change is necessary for thread assertions to work correctly. Also, I'm making the PR on this branch instead of master, because there was a change on this branch that changed instances of `pthread_t` to `thrd_t` -- this was correct, except that now we're renaming it to `tct_thrd_t`. (The version of [timer_posix.cpp on master](https://github.com/r-lib/later/blob/55f63f3e21c31bff1029704f3c71a4465e946f62/src/timer_posix.cpp) uses many `pthread_` functions, but on the private-event-loops branch they've been replaced.)