### PR TITLE
Fix build for IBM i and AIX

### DIFF
--- a/inst/include/later.h
+++ b/inst/include/later.h
@@ -5,6 +5,10 @@
 #include <iostream>
 #include <Rcpp.h>
 
+#ifdef _AIX
+#include <pthread.h>
+#endif
+
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 // Taken from http://tolstoy.newcastle.edu.au/R/e2/devel/06/11/1242.html


### PR DESCRIPTION
For IBM i and AIX, the pthread functions are not defined in this scope, so the fix is an explicit `#include`