### PR TITLE
Include pthread.h

### DIFF
--- a/inst/include/later.h
+++ b/inst/include/later.h
@@ -13,6 +13,8 @@
 // Also need to undefine the Free macro
 #undef Free
 #include <windows.h>
+#else // _WIN32
+#include <pthread.h>
 #endif // _WIN32
 
 namespace later {


### PR DESCRIPTION
This supersedes #90: pthread.h should be explicitly included for all non-Windows platforms.