### PR TITLE
Make later.h compatible with old API

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: later
 Type: Package
 Title: Utilities for Scheduling Functions to Execute Later with Event Loops
-Version: 0.8.0.9003
+Version: 0.8.0.9004
 Authors@R: c(
     person("Joe", "Cheng", role = c("aut", "cre"), email = "joe@rstudio.com"),
     person(family = "RStudio", role = "cph"),

--- a/inst/include/later.h
+++ b/inst/include/later.h
@@ -19,6 +19,17 @@
 
 namespace later {
 
+// This is the version of the later API provided by this file. Ideally, this
+// should match the version of the API provided by the later DLL that is
+// installed on the user's system. However, since this file is compiled into
+// other packages (like httpuv and promises), it is possible that there will
+// be a mismatch. In the future we will be able to compare at runtime it to
+// the result from apiVersion(), with:
+//
+// int (*dll_api_version)() = (int (*)()) R_GetCCallable("later", "apiVersion");
+// if (LATER_H_API_VERSION != (*dll_api_version)()) { ... }
+#define LATER_H_API_VERSION 2
+
 #define GLOBAL_LOOP 0
 
 inline void later(void (*func)(void*), void* data, double secs, int loop) {

--- a/inst/include/later.h
+++ b/inst/include/later.h
@@ -62,7 +62,37 @@ inline void later(void (*func)(void*), void* data, double secs, int loop) {
 }
 
 inline void later(void (*func)(void*), void* data, double secs) {
-  later(func, data, secs, GLOBAL_LOOP);
+  typedef void (*elnfun)(void (*func)(void*), void*, double);
+  static elnfun eln = NULL;
+  if (!eln) {
+    // Initialize if necessary
+    if (func) {
+      // We're not initialized but someone's trying to actually schedule
+      // some code to be executed!
+      REprintf(
+        "Warning: later::execLaterNative called in uninitialized state. "
+        "If you're using <later.h>, please switch to <later_api.h>.\n"
+      );
+    }
+    eln = (elnfun)R_GetCCallable("later", "execLaterNative");
+  }
+
+  // We didn't want to execute anything, just initialize
+  if (!func) {
+    return;
+  }
+
+  eln(func, data, secs);
+
+
+  // Note 2019-09-11: The above code in this function is here just in case a
+  // package built with this version of later.h is run with an older version
+  // of the later DLL which does not have the execLaterNative2 function. In
+  // the next release of later, after we are confident that users have
+  // installed the newer later DLL which has execLaterNative2, it should be
+  // safe to replace the code in this function with just this:
+  //
+  // later(func, data, secs, GLOBAL_LOOP);
 }
 
 

--- a/src/init.c
+++ b/src/init.c
@@ -40,6 +40,7 @@ static const R_CallMethodDef CallEntries[] = {
 
 uint64_t execLaterNative(void (*func)(void*), void* data, double secs);
 uint64_t execLaterNative2(void (*func)(void*), void* data, double secs, int loop);
+int apiVersion();
 
 void R_init_later(DllInfo *dll)
 {
@@ -63,6 +64,7 @@ void R_init_later(DllInfo *dll)
   // built against the previous version of later, we can remove this line.
   //
   // https://github.com/r-lib/later/issues/97
-  R_RegisterCCallable("later", "execLaterNative", (DL_FUNC)&execLaterNative);
+  R_RegisterCCallable("later", "execLaterNative",  (DL_FUNC)&execLaterNative);
   R_RegisterCCallable("later", "execLaterNative2", (DL_FUNC)&execLaterNative2);
+  R_RegisterCCallable("later", "apiVersion",       (DL_FUNC)&apiVersion);
 }

--- a/src/later.cpp
+++ b/src/later.cpp
@@ -297,3 +297,7 @@ extern "C" uint64_t execLaterNative2(void (*func)(void*), void* data, double del
     return 0;
   }
 }
+
+extern "C" int apiVersion() {
+  return LATER_DLL_API_VERSION;
+}

--- a/src/later.h
+++ b/src/later.h
@@ -5,6 +5,11 @@
 #include <boost/shared_ptr.hpp>
 #include "callback_registry.h"
 
+// This should be kept in sync with LATER_H_API_VERSION in
+// inst/include/later.h. Whenever the interface between inst/include/later.h
+// and the code in src/ changes, these values should be incremented.
+#define LATER_DLL_API_VERSION 2
+
 #define GLOBAL_LOOP 0
 
 boost::shared_ptr<CallbackRegistry> getCallbackRegistry(int loop);
@@ -17,5 +22,6 @@ bool idle(int loop);
 
 extern "C" uint64_t execLaterNative(void (*func)(void*), void* data, double secs);
 extern "C" uint64_t execLaterNative2(void (*func)(void*), void* data, double secs, int loop);
+extern "C" int apiVersion();
 
 #endif // _LATER_H_


### PR DESCRIPTION
This changes inst/include/later.h so that if a package is built against the new version (I'll call it V2) but run with the old version (V1) of the later DLL, it will continue to work.

It also adds a new C function `apiVersion()`, which we can use in future versions of inst/include/later.h to check for later.h and later DLL version mismatches.