### PR TITLE
Initialize execLaterNative2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: later
 Type: Package
 Title: Utilities for Scheduling Functions to Execute Later with Event Loops
-Version: 1.0.0.9001
+Version: 1.0.0.9002
 Authors@R: c(
     person("Joe", "Cheng", role = c("aut", "cre"), email = "joe@rstudio.com"),
     person(family = "RStudio", role = "cph"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
-## later 1.0.9001
+## later 1.0.0.9002
 
 * Fixed [#73](https://github.com/r-lib/later/issues/73), [#109](https://github.com/r-lib/later/issues/109): Previously, later did not build on some platforms, notably ARM, because the `-latomic` linker was needed on those platforms. A configure script now detects when `-latomic` is needed. ([#114](https://github.com/r-lib/later/pull/114))
+
+* Previously, `execLaterNative` was initialized when the package was loaded, but not `execLaterNative2`, resulting in a warning message in some cases. ([#116](https://github.com/r-lib/later/pull/116))
 
 ## later 1.0.0
 

--- a/inst/include/later_api.h
+++ b/inst/include/later_api.h
@@ -8,12 +8,14 @@ namespace {
   class LaterInitializer {
   public:
     LaterInitializer() {
-      // See comment in execLaterNative to learn why we need to do this
-      // in a statically initialized object
+      // See comment in execLaterNative2 to learn why we need to do this in a
+      // statically initialized object.
+      later::later(NULL, NULL, 0, GLOBAL_LOOP);
+      // For execLaterNative
       later::later(NULL, NULL, 0);
     }
   };
-  
+
   static LaterInitializer init;
 
 } // namespace


### PR DESCRIPTION
Previously, we did the initialization for `execLaterNative`, but we neglected to do so for `execLaterNative2`. This PR fixes that.