### PR TITLE
Ensure on.exit is called in correct order

### DIFF
--- a/R/later.R
+++ b/R/later.R
@@ -118,8 +118,8 @@ with_temp_loop <- function(expr) {
 with_loop <- function(loop, expr) {
   if (!identical(loop, current_loop())) {
     old_loop <- .globals$current_loop
-    .globals$current_loop <- loop
     on.exit(.globals$current_loop <- old_loop, add = TRUE)
+    .globals$current_loop <- loop
   }
 
   force(expr)


### PR DESCRIPTION
Prior to this change, there's a potential race condition: if an interrupt is received after the current loop is set, but before `on.exit` is called, the old loop will not be restored.