### PR TITLE
Fix for r-lib/later#126 compilation on Android

### DIFF
--- a/src/tinycthread.h
+++ b/src/tinycthread.h
@@ -117,6 +117,10 @@ extern "C" {
   #define TTHREAD_NORETURN
 #endif
 
+#ifdef __ANDROID__
+#undef TIME_UTC
+#endif
+
 /* If TIME_UTC is missing, provide it and provide a wrapper for
    timespec_get. */
 #ifndef TIME_UTC


### PR DESCRIPTION
timespec_get is not available on Android's Bionic libc -- e.g. in
sys/time.h ... This was raised as an issue in
tinycthread/tinycthread#47 and this fix is based on @mcclure's commit
https://github.com/mcclure/lovr/commit/c322ce2f04e56f6003a2798b5c8b79bf15641bcd
 ... see also android/ndk#864

### Messages

@jcheng5 if you can give this a shot, that'd be great - I ran into this issue when trying to install ```devtools``` from CRAN and I'm just sort of learning R itself, so I really have no idea if ***later*** is working as intended or not... (see below for notes on testing)

### Notes

* I tested compilation on Termux/aarch64/Android 10 and it does install (Termux currently has R v3.6.3) - since this fix checks for android using a compiler macro (i.e. ```#ifdef __ANDROID__```), the impact on any other platform should be zero. 

* I am unable to fully test on Android - Termux doesn't have a (good/working) implementation of Pandoc (the current package uses a qemu-x86_64 to run an x86_64 binary...) -- and getting a working Pandoc on Termux is really difficult right now as there is (to my knowledge) not a working Haskell compiler available. (If someone can suggest the proper method to run tests on the package without doing the Pandoc part, that'd be great! -- I tried an ```R CMD build .``` in the repo root and that's where I ran into the pandoc error...)
