### PR TITLE
Don't inlcude Rcpp.h in later.h

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: later
 Type: Package
 Title: Utilities for Scheduling Functions to Execute Later with Event Loops
-Version: 1.1.0.9000
+Version: 1.1.0.9001
 Authors@R: c(
     person("Joe", "Cheng", role = c("aut", "cre"), email = "joe@rstudio.com"),
     person(family = "RStudio", role = "cph"),

--- a/inst/include/later.h
+++ b/inst/include/later.h
@@ -3,7 +3,14 @@
 #define _later_later_h
 
 #include <iostream>
-#include <Rcpp.h>
+
+#define R_NO_REMAP
+#define STRICT_R_HEADERS
+#include <Rinternals.h>
+
+// Needed for R_GetCCallable on R 3.3 and older; in more recent versions, this
+// is included via Rinternals.h.
+#include <R_ext/Rdynload.h>
 
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN


### PR DESCRIPTION
Closes #143. This makes it so that packages which have `#include <later_api.h>` will no longer need to depend on Rcpp.