### PR TITLE
Remove dummy input handler in forked child process

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: later
 Type: Package
 Title: Utilities for Scheduling Functions to Execute Later with Event Loops
-Version: 1.2.0
+Version: 1.2.0.9000
 Authors@R: c(
     person("Winston", "Chang", role = c("aut", "cre"), email = "winston@rstudio.com"),
     person("Joe", "Cheng", role = c("aut"), email = "joe@rstudio.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## later 1.2.0.9000
+
+* Closed #148: When later was attached, `parallel::makeForkCluster()` would fail. (#149)
+
 ## later 1.2.0
 
 * Closed #138: later is now licensed as MIT. (#139)

--- a/src/later_posix.cpp
+++ b/src/later_posix.cpp
@@ -173,6 +173,8 @@ void child_proc_after_fork() {
       close(pipe_out);
       pipe_out = -1;
     }
+
+    removeInputHandler(&R_InputHandlers, dummyInputHandlerHandle);
     if (dummy_pipe_in  > 0) {
       close(dummy_pipe_in);
       dummy_pipe_in  = -1;


### PR DESCRIPTION
Closes #148.

Relevant comment from the PR that introduced the issue: https://github.com/r-lib/later/pull/141/files#r535721698

In my reply to that comment, I apparently was incorrect about it not mattering whether the dummy input handler was removed.