### PR TITLE
Use monotonically-increasing time stamps

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * Closed #148: When later was attached, `parallel::makeForkCluster()` would fail. (#149)
 
+* Fixed #150: It was possible for callbacks to execute in the wrong order if the clock time was changed in between the scheduling of two callbacks. (#151)
+
 ## later 1.2.0
 
 * Closed #138: later is now licensed as MIT. (#139)

--- a/src/timestamp_unix.cpp
+++ b/src/timestamp_unix.cpp
@@ -5,9 +5,9 @@
 #include "timeconv.h"
 
 void get_current_time(timespec *ts) {
-  timeval tv;
-  gettimeofday(&tv, NULL);
-  *ts = timevalToTimespec(tv);
+  // CLOCK_MONOTONIC ensures that we never get timestamps that go backward in
+  // time due to clock adjustment. https://github.com/r-lib/later/issues/150
+  clock_gettime(CLOCK_MONOTONIC, ts);
 }
 
 class TimestampImplPosix : public TimestampImpl {


### PR DESCRIPTION
Fixes #150. This uses `clock_gettime(CLOCK_MONOTONIC, ...)` so that timestamps are always montonically increasing, and the callbacks will execute in the correct order even if the system time is adjusted in between the scheduling of callbacks.

I considered using `CLOCK_BOOTTIME`, but it is specific to Linux, whereas `CLOCK_MONOTONIC` is part of the POSIX standard. The problem from #150 could happen on any Unix platform if the clock was adjusted, either manually or by an NTP daemon.

The existing Windows implementation uses `QueryPerformanceCounter()`, which I believe is immune to the problem, so no change was needed there.

*****

I have tested it using the Docker image from https://github.com/rstudio/shiny/issues/3429, and it uploading the file works without any corruption. To use it, run the following in a Docker container (on Mac, with Docker >=2.5.0.0), then visit the app at http://localhost:5099/. Then download the file, and upload it multiple times and check for any checksum mismatches.

```
docker run --rm -ti -p 5099:5099 fredmoser/shinyuploadissue:latest /bin/sh
apk add --no-cache g++
R -e "install.packages('remotes')"
R -e "remotes::install_github('r-lib/later@fix-clock-monotonic')"
Rscript --vanilla run.R 5099
```