### PR TITLE
Use static declaration for undeclared variable

### DIFF
--- a/src/callback_registry.cpp
+++ b/src/callback_registry.cpp
@@ -6,7 +6,7 @@
 #include "callback_registry.h"
 #include "debug.h"
 
-std::atomic<uint64_t> nextCallbackId(1);
+static std::atomic<uint64_t> nextCallbackId(1);
 
 // ============================================================================
 // Invoke functions


### PR DESCRIPTION
This was flagged by `-Wmissing-variable-declarations`. We could also (1) declare it in the header (2) but it in an anonymous namespace.