### PR TITLE
avoid duplicate names in scope

### DIFF
--- a/src/callback_registry.cpp
+++ b/src/callback_registry.cpp
@@ -338,8 +338,8 @@ bool CallbackRegistry::empty() const {
 bool CallbackRegistry::due(const Timestamp& time, bool recursive) const {
   ASSERT_MAIN_THREAD()
   Guard guard(mutex);
-  cbSet::const_iterator it = queue.begin();
-  if (!this->queue.empty() && !((*it)->when > time)) {
+  cbSet::const_iterator cbSet_it = queue.begin();
+  if (!this->queue.empty() && !((*cbSet_it)->when > time)) {
     return true;
   }
 


### PR DESCRIPTION
Flagged by `-Wshadow`.

```
cbSet::const_iterator it
std::vector<std::shared_ptr<CallbackRegistry> >::const_iterator it
```

two iterators with the same name in nearby scopes makes it a bit harder to decide which is which. Simply renamed the first one for clarity.