### PR TITLE
In C function declarations, use `void`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,7 @@ Imports:
     rlang
 LinkingTo: Rcpp
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.3
 SystemRequirements: C++11
 Suggests:
     knitr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # later (development version)
 
-
+* For C function declarations that take no parameters, added `void` parameter. (#172)
 
 # later 1.3.0
 

--- a/src/init.c
+++ b/src/init.c
@@ -9,22 +9,22 @@ Check these declarations against the C/Fortran source code.
 */
 
 /* .Call calls */
-extern SEXP _later_ensureInitialized();
+extern SEXP _later_ensureInitialized(void);
 extern SEXP _later_execCallbacks(SEXP, SEXP, SEXP);
 extern SEXP _later_idle(SEXP);
 extern SEXP _later_execLater(SEXP, SEXP, SEXP);
 extern SEXP _later_cancel(SEXP, SEXP);
 extern SEXP _later_nextOpSecs(SEXP);
-extern SEXP _later_testCallbackOrdering();
+extern SEXP _later_testCallbackOrdering(void);
 extern SEXP _later_createCallbackRegistry(SEXP, SEXP);
 extern SEXP _later_deleteCallbackRegistry(SEXP);
 extern SEXP _later_existsCallbackRegistry(SEXP);
 extern SEXP _later_notifyRRefDeleted(SEXP);
 extern SEXP _later_setCurrentRegistryId(SEXP);
-extern SEXP _later_getCurrentRegistryId();
+extern SEXP _later_getCurrentRegistryId(void);
 extern SEXP _later_list_queue_(SEXP);
 extern SEXP _later_log_level(SEXP);
-extern SEXP _later_using_ubsan();
+extern SEXP _later_using_ubsan(void);
 
 static const R_CallMethodDef CallEntries[] = {
   {"_later_ensureInitialized",      (DL_FUNC) &_later_ensureInitialized,      0},
@@ -48,7 +48,7 @@ static const R_CallMethodDef CallEntries[] = {
 
 uint64_t execLaterNative(void (*func)(void*), void* data, double secs);
 uint64_t execLaterNative2(void (*func)(void*), void* data, double secs, int loop);
-int apiVersion();
+int apiVersion(void);
 
 void R_init_later(DllInfo *dll)
 {


### PR DESCRIPTION
This fixes some warnings on R 4.3.0:

```
checking whether package ‘later’ can be installed ... WARNING
Found the following significant warnings:
  init.c:12:1: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
  init.c:18:1: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
  init.c:24:1: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
  init.c:27:1: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
  init.c:51:1: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
See https://www.r-project.org/nosvn/R.check/r-patched-linux-x86_64/later-00install.html for details.
```