### PR TITLE
hide 'unused variable' compiler warning

### DIFF
--- a/src/later_posix.cpp
+++ b/src/later_posix.cpp
@@ -245,6 +245,7 @@ void deInitialize() {
     // Trigger remove_dummy_handler()
     // Store `ret` because otherwise it raises a significant warning.
     ssize_t ret = write(dummy_pipe_in, "a", 1);
+    (void)ret; // squelch compiler warning
   }
 }
 


### PR DESCRIPTION
Copied the approach here:

https://github.com/r-lib/later/blob/bc088f896acbd09f0fde1a78e7f056ec18aadea8/src/later_posix.cpp#L54

OTOH, if `write()` fails, presumably that'll be captured in this value & we should cascade that? I don't know `write()` well enough but I'd guess `if (!ret) ...` would be better.