### PR TITLE
Fix Windows include order

### DIFF
--- a/inst/include/later.h
+++ b/inst/include/later.h
@@ -12,12 +12,6 @@
 #define STRICT_R_HEADERS
 #endif
 
-#include <Rinternals.h>
-
-// Needed for R_GetCCallable on R 3.3 and older; in more recent versions, this
-// is included via Rinternals.h.
-#include <R_ext/Rdynload.h>
-
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 // Taken from http://tolstoy.newcastle.edu.au/R/e2/devel/06/11/1242.html
@@ -29,6 +23,14 @@
 #else // _WIN32
 #include <pthread.h>
 #endif // _WIN32
+
+#include <Rinternals.h>
+
+// Needed for R_GetCCallable on R 3.3 and older; in more recent versions, this
+// is included via Rinternals.h.
+#include <R_ext/Rdynload.h>
+
+
 
 namespace later {
 


### PR DESCRIPTION
Fixes #177

As explained [in this topic](https://stackoverflow.com/a/5663743/318752) the `TRUE` and `FALSE` macros get undefined and then redefined in `<windows.h>`. 

The same is done in [R_ext/Boolean.h](https://github.com/wch/r-source/blob/trunk/src/include/R_ext/Boolean.h#L29-L36)

So we need to include `<windows.h>` before `<Rinternals.h>` to get the R version of this macro.