### PR TITLE
 Fix R CMD check warning re error() format strings (for r-devel)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * Fixed #177: The order of includes in `later.h` could cause compilation errors on some platforms. (@jeroen, #178)
 
+* Closed #181: Fix R CMD check warning re error() format strings (for r-devel). (#133)
+
 # later 1.3.1
 
 * For C function declarations that take no parameters, added `void` parameter. (#172)

--- a/src/later_posix.cpp
+++ b/src/later_posix.cpp
@@ -133,7 +133,7 @@ static void async_input_handler(void *data) {
     std::string msg = "later: exception occurred while executing callback: \n";
     msg += e.what();
     msg += "\n";
-    REprintf(msg.c_str());
+    REprintf("%s", msg.c_str());
   }
   catch( ... ){
     REprintf("later: c++ exception (unknown reason) occurred while executing callback.\n");


### PR DESCRIPTION
Closes #181

Note that this code path can be exercised with `later::later(~stop("boom"))`