### PR TITLE
Fix later error messages

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,8 +25,8 @@ RoxygenNote: 7.3.2
 Suggests:
     knitr,
     nanonext,
+    R6,
     rmarkdown,
-    testthat (>= 2.1.0),
-    R6
+    testthat (>= 2.1.0)
 VignetteBuilder: knitr
 Encoding: UTF-8

--- a/src/later_posix.cpp
+++ b/src/later_posix.cpp
@@ -126,6 +126,10 @@ static void async_input_handler(void *data) {
     DEBUG_LOG("async_input_handler: caught Rcpp::internal::InterruptedException", LOG_INFO);
     REprintf("later: interrupt occurred while executing callback.\n");
   }
+  catch(Rcpp::LongjumpException& e){
+    DEBUG_LOG("async_input_handler: caught exception", LOG_INFO);
+    REprintf("later: exception occurred while executing callback.\n");
+  }
   catch(std::exception& e){
     DEBUG_LOG("async_input_handler: caught exception", LOG_INFO);
     std::string msg = "later: exception occurred while executing callback: \n";

--- a/src/later_win32.cpp
+++ b/src/later_win32.cpp
@@ -51,6 +51,9 @@ static bool executeHandlers() {
   catch(Rcpp::internal::InterruptedException &e) {
     REprintf("later: interrupt occurred while executing callback.\n");
   }
+  catch(Rcpp::LongjumpException& e){
+    REprintf("later: exception occurred while executing callback.\n");
+  }
   catch(std::exception& e){
     std::string msg = "later: exception occurred while executing callback: \n";
     msg += e.what();

--- a/tests/testthat/test-run_now.R
+++ b/tests/testthat/test-run_now.R
@@ -238,13 +238,6 @@ test_that("interrupt and exception handling, C++", {
           Function("r_error")();
 
         } else if (value == 6) {
-          // Calls the `r_error` function via R\'s C API instead of Rcpp.
-          // Note: We don\'t actually use this for testing, because calling
-          //       Rf_eval from an Rcpp function is inherently unsafe. If an
-          //       R error occurs during the Rf_eval, a longjmp over the whole
-          //       C++ stack occurs, and the subsequent code in the function
-          //       never gets run. This function is just here to keep record of
-          //       another way that exceptions can occur.
           SEXP e;
           PROTECT(e = Rf_lang1(Rf_install("r_error")));
 
@@ -286,10 +279,16 @@ test_that("interrupt and exception handling, C++", {
   )
   expect_true(errored)
 
-
   errored <- FALSE
   tryCatch(
     { cpp_error(5); run_now() },
+    error = function(e) errored <<- TRUE
+  )
+  expect_true(errored)
+
+  errored <- FALSE
+  tryCatch(
+    { cpp_error(6); run_now() },
     error = function(e) errored <<- TRUE
   )
   expect_true(errored)

--- a/tests/testthat/test-run_now.R
+++ b/tests/testthat/test-run_now.R
@@ -238,6 +238,7 @@ test_that("interrupt and exception handling, C++", {
           Function("r_error")();
 
         } else if (value == 6) {
+          // Calls the `r_error` function via R\'s C API instead of Rcpp.
           SEXP e;
           PROTECT(e = Rf_lang1(Rf_install("r_error")));
 


### PR DESCRIPTION
Fixes #197.

The error output now shows:

```r
later::later(function() stop("oops"))
#> Error in (function ()  : oops
#> later: exception occurred while executing callback.
```

Simply by adding an additional try/catch block for `Rcpp::LongJumpException`, as the use of `Rcpp::unwindProtect()` either explicitly by us or implicitly by Rcpp when we call an `Rcpp::Function()` already converts the original C++ exception into an R error and re-throws a `Rcpp::LongJumpException`.

As I've demonstrated, the error message wasn't correct before. But compared to pre-unwind protect (2022), the one thing we've lost is that Interrupts will no longer have their own message. But I don't think this is a big loss as the interrupt itself is actually thrown. This is due to an implementation detail by Rcpp that uses `Rf_onintr()` to re-throw the interrupt without retaining any additional information. By the time it gets to us, they are all type `Rcpp::LongJumpException`.

I've retained the existing try/catch blocks so that by disabling unwind protect we can actually get back to the old behaviour. It's also a reason why I've tried to keep this fix as simple as possible.