### PR TITLE
Make `later_fd()` tests more robust

### DIFF
--- a/tests/testthat/test-later-fd.R
+++ b/tests/testthat/test-later-fd.R
@@ -14,12 +14,10 @@ test_that("later_fd", {
 
   # timeout
   later_fd(callback, c(fd1, fd2), timeout = 0)
-  Sys.sleep(0.2)
-  run_now()
+  run_now(1)
   expect_equal(result, c(FALSE, FALSE))
   later_fd(callback, c(fd1, fd2), exceptfds = c(fd1, fd2), timeout = 0)
-  Sys.sleep(0.2)
-  run_now()
+  run_now(1)
   expect_equal(result, c(FALSE, FALSE, FALSE, FALSE))
 
   # cancellation
@@ -35,57 +33,49 @@ test_that("later_fd", {
 
   # timeout (> 1 loop)
   later_fd(callback, c(fd1, fd2), timeout = 1.1)
-  Sys.sleep(1.25)
-  run_now()
+  run_now(1.3)
   expect_equal(result, c(FALSE, FALSE))
 
   # fd1 ready
   later_fd(callback, c(fd1, fd2), timeout = 0.9)
   res <- nanonext::send(s2, "msg")
-  Sys.sleep(0.2)
-  run_now()
+  run_now(1)
   expect_equal(result, c(TRUE, FALSE))
 
   # both fd1, fd2 ready
   res <- nanonext::send(s1, "msg")
   Sys.sleep(0.1)
   later_fd(callback, c(fd1, fd2), timeout = 1)
-  Sys.sleep(0.2)
-  run_now()
+  run_now(1)
   expect_equal(result, c(TRUE, TRUE))
 
   # no exceptions
   later_fd(callback, c(fd1, fd2), exceptfds = c(fd1, fd2), timeout = -0.1)
-  Sys.sleep(0.2)
-  run_now()
+  run_now(1)
   expect_equal(result, c(TRUE, TRUE, FALSE, FALSE))
 
   # fd2 ready
   res <- nanonext::recv(s1)
   later_fd(callback, c(fd1, fd2), timeout = 1L)
-  Sys.sleep(0.2)
-  run_now()
+  run_now(1)
   expect_equal(result, c(FALSE, TRUE))
 
   # fd2 invalid
   res <- nanonext::recv(s2)
   later_fd(callback, c(fd1, fd2), exceptfds = c(fd1, fd2), timeout = 0.1)
   close(s2)
-  Sys.sleep(0.2)
-  run_now()
+  run_now(1)
   expect_length(result, 4L)
 
   # both fd1, fd2 invalid
   close(s1)
   later_fd(callback, c(fd1, fd2), c(fd1, fd2), timeout = 0)
-  Sys.sleep(0.2)
-  run_now()
+  run_now(1)
   expect_equal(result, c(NA, NA, NA, NA))
 
   # no fds supplied
   later_fd(callback, timeout = -1)
-  Sys.sleep(0.2)
-  run_now()
+  run_now(1)
   expect_equal(result, logical())
 
   on.exit()
@@ -112,8 +102,7 @@ test_that("loop_empty() reflects later_fd callbacks", {
 
   later_fd(~{}, fd1, timeout = 0)
   expect_false(loop_empty())
-  Sys.sleep(0.2)
-  run_now()
+  run_now(1)
   expect_true(loop_empty())
 
 })

--- a/tests/testthat/test-later-fd.R
+++ b/tests/testthat/test-later-fd.R
@@ -50,7 +50,7 @@ test_that("later_fd", {
   res <- nanonext::send(s1, "msg")
   Sys.sleep(0.1)
   later_fd(callback, c(fd1, fd2), timeout = 1)
-  Sys.sleep(0.1)
+  Sys.sleep(0.2)
   run_now()
   expect_equal(result, c(TRUE, TRUE))
 
@@ -107,11 +107,12 @@ test_that("loop_empty() reflects later_fd callbacks", {
   cancel <- later_fd(~{}, fd1)
   expect_false(loop_empty())
   cancel()
-  Sys.sleep(1.2) # check for cancellation happens every ~1 sec
+  Sys.sleep(1.25) # check for cancellation happens every ~1 sec
   expect_true(loop_empty())
 
   later_fd(~{}, fd1, timeout = 0)
   expect_false(loop_empty())
+  Sys.sleep(0.2)
   run_now()
   expect_true(loop_empty())
 


### PR DESCRIPTION
@jcheng5 sorry I missed this - these tests have simply never failed before (including during many rhub runs), but is creating some noise on CRAN.

It's only the test without the 0.2 secs sleep before the `run_now()` that's failing. Technically, it's possible that the `later_fd()` thread hasn't sent the callback for execution yet.

As the other tests in that section are passing, I'm pretty sure it's just a timing issue.

I've also increased the sleeps to at least 0.2secs in a couple of other places to be safer.

EDIT: even better -  switched all the sleeps to blocking `run_now(1)` where possible.

The CRAN check error seems to have solved itself within a few hours, but these more robust tests will prevent it coming back.