### PR TITLE
Graceful later_fd fallback if later_api.h is newer than installed later

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -19,3 +19,26 @@ jobs:
     uses: rstudio/shiny-workflows/.github/workflows/routine.yaml@v1
   R-CMD-check:
     uses: rstudio/shiny-workflows/.github/workflows/R-CMD-check.yaml@v1
+  cpp-version-mismatch:
+    name: cpp-version-mismatch
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout GitHub repo
+        uses: rstudio/shiny-workflows/.github/internal/checkout@v1
+
+      - name: Install R, system dependencies, and package dependencies
+        uses: rstudio/shiny-workflows/setup-r-package@v1
+        with:
+          needs: check
+          extra-packages: |
+            rstudio/promises
+      - name: Downgrade later
+        run: |
+          pak::pak('cran::later@1.3.1')
+        shell: Rscript {0}
+      - name: See if dependent package (built against newer later ver) can still load
+        run: |
+          library(promises)
+        shell: Rscript {0}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -33,12 +33,17 @@ jobs:
         with:
           needs: check
           extra-packages: |
-            rstudio/promises
+            any::remotes
+      - name: Compile promises against the newest later
+        run: |
+          print(packageVersion("later"))
+          remotes::install_github("rstudio/promises")
       - name: Downgrade later
         run: |
-          pak::pak('cran::later@1.3.1')
+          remotes::install_version('later', '1.3.1')
         shell: Rscript {0}
       - name: See if dependent package (built against newer later ver) can still load
         run: |
+          print(packageVersion("later"))
           library(promises)
         shell: Rscript {0}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -38,6 +38,7 @@ jobs:
         run: |
           print(packageVersion("later"))
           remotes::install_github("rstudio/promises")
+        shell: Rscript {0}
       - name: Downgrade later
         run: |
           remotes::install_version('later', '1.3.1')

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Compile promises against the newest later
         run: |
           print(packageVersion("later"))
-          remotes::install_github("rstudio/promises")
+          remotes::install_github("rstudio/promises", force = TRUE)
         shell: Rscript {0}
       - name: Downgrade later
         run: |

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # later 1.4.0.9000 (development)
 
+* Fixed #203: Resolves an issue where packages that have `LinkingTo: later` (including `promises` and `httpuv`) and were built against `later` 1.4.0, would fail to load on systems that actually had older versions of `later` installed, erroring out with the message "function 'execLaterFdNative' not provided by package 'later'". With this fix, such dependent packages should gracefully deal with older versions at load time, and complain with helpful error messages if newer C interfaces (than are available on the installed `later`) are accessed. (#204)
+
 # later 1.4.0
 
 * Adds `later_fd()` which executes a function when a file descriptor is ready for reading or writing, at some indeterminate time in the future (subject to an optional timeout). This facilitates an event-driven approach to asynchronous or streaming downloads. (@shikokuchuo and @jcheng5, #190)

--- a/inst/include/later.h
+++ b/inst/include/later.h
@@ -55,7 +55,7 @@ namespace later {
 // Gets the version of the later API that's provided by the _actually installed_
 // version of later.
 static int apiVersionRuntime() {
-  int (*dll_api_version)() = (int (*)()) R_GetCCallable("later", "apiVersion");
+  int (*dll_api_version)(void) = (int (*)(void)) R_GetCCallable("later", "apiVersion");
   return (*dll_api_version)();
 }
 
@@ -104,6 +104,7 @@ inline void later(void (*func)(void*), void* data, double secs) {
 }
 
 static void later_fd_version_error(void (*func)(int *, void *), void *data, int num_fds, struct pollfd *fds, double secs, int loop_id) {
+  (void) func; (void) data; (void) num_fds; (void) fds; (void) secs; (void) loop_id;
   Rf_error("later_fd called, but installed version of the 'later' package is too old; please upgrade 'later' to 1.4.1 or above");
 }
 

--- a/inst/include/later.h
+++ b/inst/include/later.h
@@ -103,7 +103,7 @@ inline void later(void (*func)(void*), void* data, double secs) {
   later(func, data, secs, GLOBAL_LOOP);
 }
 
-static void later_fd_stub(void (*func)(int *, void *), void *data, int num_fds, struct pollfd *fds, double secs, int loop_id) {
+static void later_fd_version_error(void (*func)(int *, void *), void *data, int num_fds, struct pollfd *fds, double secs, int loop_id) {
   Rf_error("later_fd called, but installed version of the 'later' package is too old; please upgrade 'later' to 1.4.1 or above");
 }
 
@@ -124,9 +124,11 @@ inline void later_fd(void (*func)(int *, void *), void *data, int num_fds, struc
       );
     }
     if (apiVersionRuntime() >= 3) {
+      // Only later API version 3 supports execLaterFdNative
       elfdn = (elfdnfun) R_GetCCallable("later", "execLaterFdNative");
     } else {
-      elfdn = later_fd_stub;
+      // The installed version is too old and doesn't offer execLaterFdNative.
+      elfdn = later_fd_version_error;
     }
   }
 

--- a/inst/include/later.h
+++ b/inst/include/later.h
@@ -48,9 +48,16 @@ namespace later {
 //
 // int (*dll_api_version)() = (int (*)()) R_GetCCallable("later", "apiVersion");
 // if (LATER_H_API_VERSION != (*dll_api_version)()) { ... }
-#define LATER_H_API_VERSION 2
+#define LATER_H_API_VERSION 3
 #define GLOBAL_LOOP 0
 
+
+// Gets the version of the later API that's provided by the _actually installed_
+// version of later.
+static int apiVersionRuntime() {
+  int (*dll_api_version)() = (int (*)()) R_GetCCallable("later", "apiVersion");
+  return (*dll_api_version)();
+}
 
 inline void later(void (*func)(void*), void* data, double secs, int loop_id) {
   // This function works by retrieving the later::execLaterNative2 function
@@ -96,6 +103,10 @@ inline void later(void (*func)(void*), void* data, double secs) {
   later(func, data, secs, GLOBAL_LOOP);
 }
 
+static void later_fd_stub(void (*func)(int *, void *), void *data, int num_fds, struct pollfd *fds, double secs, int loop_id) {
+  Rf_error("later_fd called, but installed version of the 'later' package is too old; please upgrade 'later' to 1.4.1 or above");
+}
+
 inline void later_fd(void (*func)(int *, void *), void *data, int num_fds, struct pollfd *fds, double secs, int loop_id) {
   // See above note for later()
 
@@ -112,7 +123,11 @@ inline void later_fd(void (*func)(int *, void *), void *data, int num_fds, struc
         "If you're using <later.h>, please switch to <later_api.h>.\n"
       );
     }
-    elfdn = (elfdnfun) R_GetCCallable("later", "execLaterFdNative");
+    if (apiVersionRuntime() >= 3) {
+      elfdn = (elfdnfun) R_GetCCallable("later", "execLaterFdNative");
+    } else {
+      elfdn = later_fd_stub;
+    }
   }
 
   // We didn't want to execute anything, just initialize

--- a/inst/include/later.h
+++ b/inst/include/later.h
@@ -123,7 +123,7 @@ inline void later_fd(void (*func)(int *, void *), void *data, int num_fds, struc
         "If you're using <later.h>, please switch to <later_api.h>.\n"
       );
     }
-    if (apiVersionRuntime() >= 3) {
+    if (true || apiVersionRuntime() >= 3) {
       // Only later API version 3 supports execLaterFdNative
       elfdn = (elfdnfun) R_GetCCallable("later", "execLaterFdNative");
     } else {

--- a/inst/include/later.h
+++ b/inst/include/later.h
@@ -123,7 +123,7 @@ inline void later_fd(void (*func)(int *, void *), void *data, int num_fds, struc
         "If you're using <later.h>, please switch to <later_api.h>.\n"
       );
     }
-    if (true || apiVersionRuntime() >= 3) {
+    if (apiVersionRuntime() >= 3) {
       // Only later API version 3 supports execLaterFdNative
       elfdn = (elfdnfun) R_GetCCallable("later", "execLaterFdNative");
     } else {

--- a/src/later.h
+++ b/src/later.h
@@ -8,7 +8,7 @@
 // This should be kept in sync with LATER_H_API_VERSION in
 // inst/include/later.h. Whenever the interface between inst/include/later.h
 // and the code in src/ changes, these values should be incremented.
-#define LATER_DLL_API_VERSION 2
+#define LATER_DLL_API_VERSION 3
 
 #define GLOBAL_LOOP 0
 


### PR DESCRIPTION
Fixes #203 

To test:

```r
devtools::install_github("r-lib/later#204")
install.packages("promises", type="source")
devtools::install_version("later", "1.3.1")
```

then restart R and `library(promises)`

- [x] Un-break inst/include/later.h