### PR TITLE
Fix later_api.h is newer than installed later 

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -4,14 +4,8 @@
 # For most R packages it is better to use https://github.com/r-lib/actions
 on:
   push:
-    branches: [main, rc-**]
   pull_request:
-    branches: [main]
-  schedule:
-    - cron:  '0 5 * * 1' # every monday
-
 name: Package checks
-
 jobs:
   website:
     uses: rstudio/shiny-workflows/.github/workflows/website.yaml@v1
@@ -19,3 +13,32 @@ jobs:
     uses: rstudio/shiny-workflows/.github/workflows/routine.yaml@v1
   R-CMD-check:
     uses: rstudio/shiny-workflows/.github/workflows/R-CMD-check.yaml@v1
+  cpp-version-mismatch:
+    name: cpp-version-mismatch
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout GitHub repo
+        uses: rstudio/shiny-workflows/.github/internal/checkout@v1
+
+      - name: Install R, system dependencies, and package dependencies
+        uses: rstudio/shiny-workflows/setup-r-package@v1
+        with:
+          needs: check
+          extra-packages: |
+            any::remotes
+      - name: Compile promises against the newest later
+        run: |
+          print(packageVersion("later"))
+          remotes::install_github("rstudio/promises", force = TRUE)
+        shell: Rscript {0}
+      - name: Downgrade later
+        run: |
+          remotes::install_version('later', '1.3.1')
+        shell: Rscript {0}
+      - name: See if dependent package (built against newer later ver) can still load
+        run: |
+          print(packageVersion("later"))
+          library(promises)
+        shell: Rscript {0}


### PR DESCRIPTION
This somehow errors with:

```r
Error in .Internal(dyn.load(x, as.logical(local), as.logical(now), "")) : 
  function 'execLaterFdNative' not provided by package 'later'
```

after going through the steps here: https://github.com/r-lib/later/pull/204#issue-2699393078.

@jcheng5 @wch 