### PR TITLE
Fix `keyword is hidden by macro definition` compiler warning

### DIFF
--- a/src/badthreads.h
+++ b/src/badthreads.h
@@ -45,7 +45,7 @@
 #define cnd_wait            THREADS_H_ERROR
 #define cnd_timedwait       THREADS_H_ERROR
 #define cnd_destroy         THREADS_H_ERROR
-#define thread_local        THREADS_H_ERROR
+// #define thread_local        THREADS_H_ERROR /* Don't redefine thread_local as it is a keyword in C23 */
 #define tss_t               THREADS_H_ERROR
 #define TSS_DTOR_ITERATIONS THREADS_H_ERROR
 #define tss_dtor_t          THREADS_H_ERROR

--- a/src/fd.cpp
+++ b/src/fd.cpp
@@ -119,7 +119,7 @@ static int wait_thread(void *arg) {
   do {
     // Never wait for longer than ~1 second so we can check for cancellation
     waitFor = std::fmin(waitFor, 1.024);
-    ready = LATER_POLL_FUNC(args->fds.data(), args->fds.size(), static_cast<int>(waitFor * 1000));
+    ready = LATER_POLL_FUNC(args->fds.data(), static_cast<LATER_NFDS_T>(args->fds.size()), static_cast<int>(waitFor * 1000));
     if (!args->active->load()) return 1;
     if (ready) break;
   } while ((waitFor = args->timeout.diff_secs(Timestamp())) > 0);

--- a/src/fd.h
+++ b/src/fd.h
@@ -12,8 +12,10 @@
 
 #ifdef _WIN32
 #define LATER_POLL_FUNC WSAPoll
+#define LATER_NFDS_T ULONG
 #else
 #define LATER_POLL_FUNC poll
+#define LATER_NFDS_T nfds_t
 #endif
 
 #endif // _LATER_FD_H_

--- a/src/timeconv.h
+++ b/src/timeconv.h
@@ -18,20 +18,20 @@ inline timespec timevalToTimespec(const timeval& tv) {
 inline timeval timespecToTimeval(const timespec& ts) {
   timeval tv;
   tv.tv_sec = ts.tv_sec;
-  tv.tv_usec = ts.tv_nsec / 1000;
+  tv.tv_usec = (suseconds_t) (ts.tv_nsec / 1000);
   return tv;
 }
 
 inline timespec addSeconds(const timespec& time, double secs) {
   timespec ts = time;
   ts.tv_sec += (time_t)secs;
-  ts.tv_nsec += (secs - (time_t)secs) * 1e9;
+  ts.tv_nsec += (secs - (time_t)secs) * 1e9L;
   if (ts.tv_nsec < 0) {
-    ts.tv_nsec += 1e9;
+    ts.tv_nsec += 1e9L;
     ts.tv_sec--;
   }
-  if (ts.tv_nsec >= 1e9) {
-    ts.tv_nsec -= 1e9;
+  if (ts.tv_nsec >= 1e9L) {
+    ts.tv_nsec -= 1e9L;
     ts.tv_sec++;
   }
   return ts;


### PR DESCRIPTION
Fixes #208.

As `thread_local` is a keyword in C23, we shouldn't be redefining it using a macro. As it's only in `badthreads.h` as 'protection', I've just commented this line out. I could conditionally define on the C23 standard, but I don't fully trust all CRAN test machines to have this set correctly (e.g. if using pre-release compiler versions), so I take the simpler option. If everything else in that header is defined as an error, I don't think this one item makes a difference.

The second commit eliminates the implicit type conversions, which I don't think is necessary by any means, but I prefer to err on the side of caution here as well. They also seem low risk so I've included them.