### PR TITLE
Remove RNGScope usage for Rcpp exports

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # later (development version)
 
-* Set file-level variables as `static` to avoid triggering `-Wmissing-variable-declarations` (@michaelchirico)
+* Fixed #167: `.Random.seed` is no longer affected when the package is loaded (#220).
+
+* Set file-level variables as `static` to avoid triggering `-Wmissing-variable-declarations` (@michaelchirico, #163).
 
 # later 1.4.2
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -15,7 +15,6 @@ Rcpp::Rostream<false>& Rcpp::Rcerr = Rcpp::Rcpp_cerr_get();
 void testCallbackOrdering();
 RcppExport SEXP _later_testCallbackOrdering() {
 BEGIN_RCPP
-    Rcpp::RNGScope rcpp_rngScope_gen;
     testCallbackOrdering();
     return R_NilValue;
 END_RCPP
@@ -25,7 +24,6 @@ std::string log_level(std::string level);
 RcppExport SEXP _later_log_level(SEXP levelSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< std::string >::type level(levelSEXP);
     rcpp_result_gen = Rcpp::wrap(log_level(level));
     return rcpp_result_gen;
@@ -36,7 +34,6 @@ bool using_ubsan();
 RcppExport SEXP _later_using_ubsan() {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
     rcpp_result_gen = Rcpp::wrap(using_ubsan());
     return rcpp_result_gen;
 END_RCPP
@@ -46,7 +43,6 @@ Rcpp::RObject execLater_fd(Rcpp::Function callback, Rcpp::IntegerVector readfds,
 RcppExport SEXP _later_execLater_fd(SEXP callbackSEXP, SEXP readfdsSEXP, SEXP writefdsSEXP, SEXP exceptfdsSEXP, SEXP timeoutSecsSEXP, SEXP loop_idSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< Rcpp::Function >::type callback(callbackSEXP);
     Rcpp::traits::input_parameter< Rcpp::IntegerVector >::type readfds(readfdsSEXP);
     Rcpp::traits::input_parameter< Rcpp::IntegerVector >::type writefds(writefdsSEXP);
@@ -62,7 +58,6 @@ Rcpp::LogicalVector fd_cancel(Rcpp::RObject xptr);
 RcppExport SEXP _later_fd_cancel(SEXP xptrSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< Rcpp::RObject >::type xptr(xptrSEXP);
     rcpp_result_gen = Rcpp::wrap(fd_cancel(xptr));
     return rcpp_result_gen;
@@ -72,7 +67,6 @@ END_RCPP
 void setCurrentRegistryId(int id);
 RcppExport SEXP _later_setCurrentRegistryId(SEXP idSEXP) {
 BEGIN_RCPP
-    Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< int >::type id(idSEXP);
     setCurrentRegistryId(id);
     return R_NilValue;
@@ -83,7 +77,6 @@ int getCurrentRegistryId();
 RcppExport SEXP _later_getCurrentRegistryId() {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
     rcpp_result_gen = Rcpp::wrap(getCurrentRegistryId());
     return rcpp_result_gen;
 END_RCPP
@@ -93,7 +86,6 @@ bool deleteCallbackRegistry(int loop_id);
 RcppExport SEXP _later_deleteCallbackRegistry(SEXP loop_idSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< int >::type loop_id(loop_idSEXP);
     rcpp_result_gen = Rcpp::wrap(deleteCallbackRegistry(loop_id));
     return rcpp_result_gen;
@@ -104,7 +96,6 @@ bool notifyRRefDeleted(int loop_id);
 RcppExport SEXP _later_notifyRRefDeleted(SEXP loop_idSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< int >::type loop_id(loop_idSEXP);
     rcpp_result_gen = Rcpp::wrap(notifyRRefDeleted(loop_id));
     return rcpp_result_gen;
@@ -114,7 +105,6 @@ END_RCPP
 void createCallbackRegistry(int id, int parent_id);
 RcppExport SEXP _later_createCallbackRegistry(SEXP idSEXP, SEXP parent_idSEXP) {
 BEGIN_RCPP
-    Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< int >::type id(idSEXP);
     Rcpp::traits::input_parameter< int >::type parent_id(parent_idSEXP);
     createCallbackRegistry(id, parent_id);
@@ -126,7 +116,6 @@ bool existsCallbackRegistry(int id);
 RcppExport SEXP _later_existsCallbackRegistry(SEXP idSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< int >::type id(idSEXP);
     rcpp_result_gen = Rcpp::wrap(existsCallbackRegistry(id));
     return rcpp_result_gen;
@@ -137,7 +126,6 @@ Rcpp::List list_queue_(int id);
 RcppExport SEXP _later_list_queue_(SEXP idSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< int >::type id(idSEXP);
     rcpp_result_gen = Rcpp::wrap(list_queue_(id));
     return rcpp_result_gen;
@@ -148,7 +136,6 @@ bool execCallbacks(double timeoutSecs, bool runAll, int loop_id);
 RcppExport SEXP _later_execCallbacks(SEXP timeoutSecsSEXP, SEXP runAllSEXP, SEXP loop_idSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< double >::type timeoutSecs(timeoutSecsSEXP);
     Rcpp::traits::input_parameter< bool >::type runAll(runAllSEXP);
     Rcpp::traits::input_parameter< int >::type loop_id(loop_idSEXP);
@@ -161,7 +148,6 @@ bool idle(int loop_id);
 RcppExport SEXP _later_idle(SEXP loop_idSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< int >::type loop_id(loop_idSEXP);
     rcpp_result_gen = Rcpp::wrap(idle(loop_id));
     return rcpp_result_gen;
@@ -171,7 +157,6 @@ END_RCPP
 void ensureInitialized();
 RcppExport SEXP _later_ensureInitialized() {
 BEGIN_RCPP
-    Rcpp::RNGScope rcpp_rngScope_gen;
     ensureInitialized();
     return R_NilValue;
 END_RCPP
@@ -181,7 +166,6 @@ std::string execLater(Rcpp::Function callback, double delaySecs, int loop_id);
 RcppExport SEXP _later_execLater(SEXP callbackSEXP, SEXP delaySecsSEXP, SEXP loop_idSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< Rcpp::Function >::type callback(callbackSEXP);
     Rcpp::traits::input_parameter< double >::type delaySecs(delaySecsSEXP);
     Rcpp::traits::input_parameter< int >::type loop_id(loop_idSEXP);
@@ -194,7 +178,6 @@ bool cancel(std::string callback_id_s, int loop_id);
 RcppExport SEXP _later_cancel(SEXP callback_id_sSEXP, SEXP loop_idSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< std::string >::type callback_id_s(callback_id_sSEXP);
     Rcpp::traits::input_parameter< int >::type loop_id(loop_idSEXP);
     rcpp_result_gen = Rcpp::wrap(cancel(callback_id_s, loop_id));
@@ -206,7 +189,6 @@ double nextOpSecs(int loop_id);
 RcppExport SEXP _later_nextOpSecs(SEXP loop_idSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< int >::type loop_id(loop_idSEXP);
     rcpp_result_gen = Rcpp::wrap(nextOpSecs(loop_id));
     return rcpp_result_gen;

--- a/src/callback_registry.cpp
+++ b/src/callback_registry.cpp
@@ -215,7 +215,7 @@ Rcpp::RObject RcppFunctionCallback::rRepresentation() const {
 // CallbackRegistry
 // ============================================================================
 
-// [[Rcpp::export]]
+// [[Rcpp::export(rng = false)]]
 void testCallbackOrdering() {
   std::vector<StdFunctionCallback> callbacks;
   Timestamp ts;

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -38,7 +38,7 @@ LogLevel log_level_ = LOG_ERROR;
 
 
 // Sets the current log level and returns previous value.
-// [[Rcpp::export]]
+// [[Rcpp::export(rng = false)]]
 std::string log_level(std::string level) {
   LogLevel old_level = log_level_;
 
@@ -69,7 +69,7 @@ std::string log_level(std::string level) {
 }
 
 // Reports whether package was compiled with UBSAN
-// [[Rcpp::export]]
+// [[Rcpp::export(rng = false)]]
 bool using_ubsan() {
 #ifdef USING_UBSAN
   return true;

--- a/src/fd.cpp
+++ b/src/fd.cpp
@@ -171,7 +171,7 @@ static int execLater_fd_native(void (*func)(int *, void *), void *data, int num_
 
 }
 
-// [[Rcpp::export]]
+// [[Rcpp::export(rng = false)]]
 Rcpp::RObject execLater_fd(Rcpp::Function callback, Rcpp::IntegerVector readfds, Rcpp::IntegerVector writefds,
                            Rcpp::IntegerVector exceptfds, Rcpp::NumericVector timeoutSecs, Rcpp::IntegerVector loop_id) {
 
@@ -209,7 +209,7 @@ Rcpp::RObject execLater_fd(Rcpp::Function callback, Rcpp::IntegerVector readfds,
 
 }
 
-// [[Rcpp::export]]
+// [[Rcpp::export(rng = false)]]
 Rcpp::LogicalVector fd_cancel(Rcpp::RObject xptr) {
 
   Rcpp::XPtr<std::shared_ptr<std::atomic<bool>>> active(xptr);

--- a/src/later.cpp
+++ b/src/later.cpp
@@ -86,13 +86,13 @@ bool at_top_level() {
 
 static int current_registry;
 
-// [[Rcpp::export]]
+// [[Rcpp::export(rng = false)]]
 void setCurrentRegistryId(int id) {
   ASSERT_MAIN_THREAD()
   current_registry = id;
 }
 
-// [[Rcpp::export]]
+// [[Rcpp::export(rng = false)]]
 int getCurrentRegistryId() {
   ASSERT_MAIN_THREAD()
   return current_registry;
@@ -131,7 +131,7 @@ shared_ptr<CallbackRegistry> getGlobalRegistry() {
 // parent. Any children of this registry are orphaned -- they no longer have a
 // parent. (Maybe this should be an option?)
 //
-// [[Rcpp::export]]
+// [[Rcpp::export(rng = false)]]
 bool deleteCallbackRegistry(int loop_id) {
   ASSERT_MAIN_THREAD()
   if (loop_id == GLOBAL_LOOP) {
@@ -146,7 +146,7 @@ bool deleteCallbackRegistry(int loop_id) {
 
 
 // This is called when the R loop handle is GC'd.
-// [[Rcpp::export]]
+// [[Rcpp::export(rng = false)]]
 bool notifyRRefDeleted(int loop_id) {
   ASSERT_MAIN_THREAD()
   if (loop_id == GLOBAL_LOOP) {
@@ -160,19 +160,19 @@ bool notifyRRefDeleted(int loop_id) {
 }
 
 
-// [[Rcpp::export]]
+// [[Rcpp::export(rng = false)]]
 void createCallbackRegistry(int id, int parent_id) {
   ASSERT_MAIN_THREAD()
   callbackRegistryTable.create(id, parent_id);
 }
 
-// [[Rcpp::export]]
+// [[Rcpp::export(rng = false)]]
 bool existsCallbackRegistry(int id) {
   ASSERT_MAIN_THREAD()
   return callbackRegistryTable.exists(id);
 }
 
-// [[Rcpp::export]]
+// [[Rcpp::export(rng = false)]]
 Rcpp::List list_queue_(int id) {
   ASSERT_MAIN_THREAD()
   shared_ptr<CallbackRegistry> registry = callbackRegistryTable.getRegistry(id);
@@ -230,7 +230,7 @@ bool execCallbacksOne(
 }
 
 // Execute callbacks for an event loop and its children.
-// [[Rcpp::export]]
+// [[Rcpp::export(rng = false)]]
 bool execCallbacks(double timeoutSecs, bool runAll, int loop_id) {
   ASSERT_MAIN_THREAD()
   shared_ptr<CallbackRegistry> registry = callbackRegistryTable.getRegistry(loop_id);
@@ -275,7 +275,7 @@ bool execCallbacksForTopLevel() {
   return any;
 }
 
-// [[Rcpp::export]]
+// [[Rcpp::export(rng = false)]]
 bool idle(int loop_id) {
   ASSERT_MAIN_THREAD()
   shared_ptr<CallbackRegistry> registry = callbackRegistryTable.getRegistry(loop_id);
@@ -287,7 +287,7 @@ bool idle(int loop_id) {
 
 
 static bool initialized = false;
-// [[Rcpp::export]]
+// [[Rcpp::export(rng = false)]]
 void ensureInitialized() {
   if (initialized) {
     return;
@@ -304,7 +304,7 @@ void ensureInitialized() {
   initialized = true;
 }
 
-// [[Rcpp::export]]
+// [[Rcpp::export(rng = false)]]
 std::string execLater(Rcpp::Function callback, double delaySecs, int loop_id) {
   ASSERT_MAIN_THREAD()
   ensureInitialized();
@@ -330,7 +330,7 @@ bool cancel(uint64_t callback_id, int loop_id) {
   return registry->cancel(callback_id);
 }
 
-// [[Rcpp::export]]
+// [[Rcpp::export(rng = false)]]
 bool cancel(std::string callback_id_s, int loop_id) {
   ASSERT_MAIN_THREAD()
   uint64_t callback_id;
@@ -348,7 +348,7 @@ bool cancel(std::string callback_id_s, int loop_id) {
 
 
 
-// [[Rcpp::export]]
+// [[Rcpp::export(rng = false)]]
 double nextOpSecs(int loop_id) {
   ASSERT_MAIN_THREAD()
   shared_ptr<CallbackRegistry> registry = callbackRegistryTable.getRegistry(loop_id);


### PR DESCRIPTION
Closes #167.

This uses the `Rcpp::export(rng = false)` directive to opt out of Rcpp automatically adding `RNGScope` to our exported functions.

We do not make use of the R RNG, so this is safe to do, and is a 'free' boost to performance.

Crucially we still leave this [RNGScope](https://github.com/r-lib/later/blob/main/src/later.cpp#L195) on the stack when evaluating all user callback code.

The original issue is solved:

``` r
.Random.seed <- NULL
library(later)
.Random.seed
#> NULL
```

<sup>Created on 2025-07-28 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

I also ran a revdepcheck to be sure this doesn't affect downstream code.

@wch @jcheng5 fyi, pls shout if you see any problems with this.