### PR TITLE
Remove deprecated `autorun` argument at `create_loop()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # later (development version)
 
+* Fixed #215: The `autorun` argument of `create_loop()`, long deprecated, is removed (#222).
+
 * Fixed #167: `.Random.seed` is no longer affected when the package is loaded (#220).
 
 * Set file-level variables as `static` to avoid triggering `-Wmissing-variable-declarations` (@michaelchirico, #163).

--- a/R/later.R
+++ b/R/later.R
@@ -61,8 +61,6 @@ wref_key <- function(w) {
 #'
 #' @param loop A handle to an event loop.
 #' @param expr An expression to evaluate.
-#' @param autorun This exists only for backward compatibility. If set to
-#'   \code{FALSE}, it is equivalent to using \code{parent=NULL}.
 #' @param parent The parent event loop for the one being created. Whenever the
 #'   parent loop runs, this loop will also automatically run, without having to
 #'   manually call \code{\link{run_now}()} on this loop. If \code{NULL}, then
@@ -72,22 +70,10 @@ wref_key <- function(w) {
 #' @rdname create_loop
 #'
 #' @export
-create_loop <- function(parent = current_loop(), autorun = NULL) {
+create_loop <- function(parent = current_loop()) {
   id <- .globals$next_id
   .globals$next_id <- id + 1L
 
-  if (!is.null(autorun)) {
-    # This is for backward compatibility, if `create_loop(autorun=FALSE)` is called.
-    parent <- NULL
-  }
-  if (identical(parent, FALSE)) {
-    # This is for backward compatibility, if `create_loop(FALSE)` is called.
-    # (Previously the first and only parameter was `autorun`.)
-    parent <- NULL
-    warning(
-      "create_loop(FALSE) is deprecated. Please use create_loop(parent=NULL) from now on."
-    )
-  }
   if (!is.null(parent) && !inherits(parent, "event_loop")) {
     stop("`parent` must be NULL or an event_loop object.")
   }

--- a/man/create_loop.Rd
+++ b/man/create_loop.Rd
@@ -10,7 +10,7 @@
 \alias{global_loop}
 \title{Private event loops}
 \usage{
-create_loop(parent = current_loop(), autorun = NULL)
+create_loop(parent = current_loop())
 
 destroy_loop(loop)
 
@@ -31,9 +31,6 @@ manually call \code{\link{run_now}()} on this loop. If \code{NULL}, then
 this loop will not have a parent event loop that automatically runs it; the
 only way to run this loop will be by calling \code{\link{run_now}()} on this
 loop.}
-
-\item{autorun}{This exists only for backward compatibility. If set to
-\code{FALSE}, it is equivalent to using \code{parent=NULL}.}
 
 \item{loop}{A handle to an event loop.}
 


### PR DESCRIPTION
Closes #215. Use of this argument has produced a deprecation warning for 5 yrs now so should be safe to remove.