### PR TITLE
Reduce waiting time to call back the input handler

### DIFF
--- a/src/later_posix.cpp
+++ b/src/later_posix.cpp
@@ -99,7 +99,7 @@ static void async_input_handler(void *data) {
     // Instead, we set the file descriptor to cold, and tell the timer to fire
     // again in a few milliseconds. This should give enough breathing room that
     // we don't interfere with the sockets too much.
-    timer.set(Timestamp(0.0));
+    timer.set(Timestamp(0.01));
     return;
   }
 


### PR DESCRIPTION
Closes #221.

Setting the time to zero appears to work. Need to test using the original reprex in #4 on a wider range of machines.