### PR TITLE
Removes old execLaterNative code path

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -55,8 +55,7 @@ static const R_CallMethodDef CallEntries[] = {
   {NULL, NULL, 0}
 };
 
-uint64_t execLaterNative(void (*func)(void*), void* data, double secs);
-uint64_t execLaterNative2(void (*func)(void*), void* data, double secs, int loop);
+uint64_t execLaterNative2(void (*)(void*), void*, double, int);
 int execLaterFdNative(void (*)(int *, void *), void *, int, struct pollfd *, double, int);
 int apiVersion(void);
 
@@ -64,25 +63,6 @@ void R_init_later(DllInfo *dll) {
   R_registerRoutines(dll, NULL, CallEntries, NULL, NULL);
   R_useDynamicSymbols(dll, FALSE);
   R_forceSymbols(dll, TRUE);
-  // 2019-08-06
-  // execLaterNative is registered here ONLY for backward compatibility; If
-  // someone installed a package which had `#include <later_api.h>` (like
-  // httpuv) then that package would have compiled the inline functions from
-  // inst/include/later.h, which in turn used `R_GetCCallable("later",
-  // "execLaterNative")`, then called that function with 3 arguments. For
-  // anyone who upgrades this package but does not upgrade the downstream
-  // dependency, that interface cannot change.
-  //
-  // So we register `execLaterNative` here, even though we don't actually call
-  // it from inst/include/later.h anymore. This ensures that downstream deps
-  // that were built with the previous version can still use
-  // `R_GetCCallable("later", "execLaterNative")` and have it work properly.
-  //
-  // In a future version, after no one is running downstream packages that are
-  // built against the previous version of later, we can remove this line.
-  //
-  // https://github.com/r-lib/later/issues/97
-  R_RegisterCCallable("later", "execLaterNative",  (DL_FUNC)&execLaterNative);
   R_RegisterCCallable("later", "execLaterNative2", (DL_FUNC)&execLaterNative2);
   R_RegisterCCallable("later", "execLaterFdNative",(DL_FUNC)&execLaterFdNative);
   R_RegisterCCallable("later", "apiVersion",       (DL_FUNC)&apiVersion);

--- a/src/later.cpp
+++ b/src/later.cpp
@@ -365,12 +365,6 @@ double nextOpSecs(int loop_id) {
   }
 }
 
-// Schedules a C function to execute on the global loop. Returns callback ID
-// on success, or 0 on error.
-extern "C" uint64_t execLaterNative(void (*func)(void*), void* data, double delaySecs) {
-  return execLaterNative2(func, data, delaySecs, GLOBAL_LOOP);
-}
-
 // Schedules a C function to execute on a specific event loop. Returns
 // callback ID on success, or 0 on error.
 extern "C" uint64_t execLaterNative2(void (*func)(void*), void* data, double delaySecs, int loop_id) {

--- a/src/later.h
+++ b/src/later.h
@@ -20,10 +20,6 @@ bool at_top_level();
 bool execCallbacks(double timeoutSecs, bool runAll, int loop_id);
 bool idle(int loop);
 
-extern "C" uint64_t execLaterNative(void (*func)(void*), void* data, double secs);
-extern "C" uint64_t execLaterNative2(void (*func)(void*), void* data, double secs, int loop_id);
-extern "C" int apiVersion();
-
 void ensureInitialized();
 // Declare platform-specific functions that are implemented in later_posix.cpp
 // and later_win32.cpp.


### PR DESCRIPTION
Closes #105.

It's safe to assume that after all this time, no one is depending on the old `execLaterNative()` interface, given this is not used by the installed header `later_api.h`. This would theoretically affect current versions of later being used with 6yr old binaries of e.g. httpuv.