### PR TITLE
Pass `Rcpp::Function` as const ref

### DIFF
--- a/src/callback_registry.cpp
+++ b/src/callback_registry.cpp
@@ -191,7 +191,7 @@ Rcpp::RObject StdFunctionCallback::rRepresentation() const {
 // RcppFunctionCallback
 // ============================================================================
 
-RcppFunctionCallback::RcppFunctionCallback(Timestamp when, Rcpp::Function func) :
+RcppFunctionCallback::RcppFunctionCallback(Timestamp when, const Rcpp::Function& func) :
   Callback(when),
   func(func)
 {
@@ -258,7 +258,7 @@ int CallbackRegistry::getId() const {
   return id;
 }
 
-uint64_t CallbackRegistry::add(Rcpp::Function func, double secs) {
+uint64_t CallbackRegistry::add(const Rcpp::Function& func, double secs) {
   // Copies of the Rcpp::Function should only be made on the main thread.
   ASSERT_MAIN_THREAD()
   Timestamp when(secs);

--- a/src/callback_registry.h
+++ b/src/callback_registry.h
@@ -76,7 +76,7 @@ private:
 
 class RcppFunctionCallback : public Callback {
 public:
-  RcppFunctionCallback(Timestamp when, Rcpp::Function func);
+  RcppFunctionCallback(Timestamp when, const Rcpp::Function& func);
 
   void invoke() const {
     func();
@@ -131,7 +131,7 @@ public:
 
   // Add a function to the registry, to be executed at `secs` seconds in
   // the future (i.e. relative to the current time).
-  uint64_t add(Rcpp::Function func, double secs);
+  uint64_t add(const Rcpp::Function& func, double secs);
 
   // Add a C function to the registry, to be executed at `secs` seconds in
   // the future (i.e. relative to the current time).


### PR DESCRIPTION
Closes #43. Updates a couple of usages, const ref already being used in the more recent `later_fd()` implementation.