### PR TITLE
Efficiency: Replace Callback_sp `take()` method with `pop()`

### DIFF
--- a/src/callback_registry.cpp
+++ b/src/callback_registry.cpp
@@ -361,16 +361,16 @@ bool CallbackRegistry::due(const Timestamp& time, bool recursive) const {
   return false;
 }
 
-std::vector<Callback_sp> CallbackRegistry::take(size_t max, const Timestamp& time) {
+Callback_sp CallbackRegistry::pop(const Timestamp& time) {
   ASSERT_MAIN_THREAD()
   Guard guard(mutex);
-  std::vector<Callback_sp> results;
-  while (this->due(time, false) && (max <= 0 || results.size() < max)) {
+  Callback_sp result;
+  if (this->due(time, false)) {
     cbSet::iterator it = queue.begin();
-    results.push_back(*it);
+    result = *it;
     this->queue.erase(it);
   }
-  return results;
+  return result;
 }
 
 bool CallbackRegistry::wait(double timeoutSecs, bool recursive) const {

--- a/src/callback_registry.h
+++ b/src/callback_registry.h
@@ -150,8 +150,8 @@ public:
   // Is anything ready to execute?
   bool due(const Timestamp& time = Timestamp(), bool recursive = true) const;
 
-  // Pop and return an ordered list of functions to execute now.
-  std::vector<Callback_sp> take(size_t max = -1, const Timestamp& time = Timestamp());
+  // Pop and return a function to execute now.
+  Callback_sp pop(const Timestamp& time = Timestamp());
 
   // Wait until the next available callback is ready to execute.
   bool wait(double timeoutSecs, bool recursive) const;

--- a/src/later.cpp
+++ b/src/later.cpp
@@ -201,17 +201,17 @@ bool execCallbacksOne(
   do {
     // We only take one at a time, because we don't want to lose callbacks if
     // one of the callbacks throws an error
-    std::vector<Callback_sp> callbacks = callback_registry->take(1, now);
-    if (callbacks.size() == 0) {
+    Callback_sp callback = callback_registry->pop(now);
+    if (callback == nullptr) {
       break;
     }
 
 #ifdef RCPP_USING_UNWIND_PROTECT // See https://github.com/r-lib/later/issues/191
     // This line may throw errors!
-    callbacks[0]->invoke();
+    callback->invoke();
 #else
     // This line may throw errors!
-    callbacks[0]->invoke_wrapped();
+    callback->invoke_wrapped();
 #endif
 
   } while (runAll);


### PR DESCRIPTION
Identified, but not implemented, by Claude Code.

As we only ever `take(1)`, we can remove the wrapping of all callbacks in a std::vector container.
This should reduce allocations and improve performance.
