### PR TITLE
later 1.4.3

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Type: Package
 Package: later
 Title: Utilities for Scheduling Functions to Execute Later with Event
     Loops
-Version: 1.4.2.9000
+Version: 1.4.3
 Authors@R: c(
     person("Winston", "Chang", , "winston@posit.co", role = "aut"),
     person("Joe", "Cheng", , "joe@posit.co", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# later (development version)
+# later 1.4.3
 
 * Fixed #215: The `autorun` argument of `create_loop()`, long deprecated, is removed (#222).
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,11 +1,16 @@
 ## R CMD check results
 
-0 errors | 0 warnings | 0 notes
+0 errors | 0 warnings | 1 note
+
+  New maintainer:
+    Charlie Gao <charlie.gao@posit.co>
+  Old maintainer(s):
+    Winston Chang <winston@posit.co>
 
 ## revdepcheck results
 
-We checked 31 reverse dependencies (26 from CRAN + 5 from Bioconductor), comparing R CMD check results across CRAN and dev versions of this package.
+We checked 33 reverse dependencies (31 from CRAN + 2 from Bioconductor), comparing R CMD check results across CRAN and dev versions of this package.
 
  * We saw 0 new problems
- * We failed to check 0 packages
+ * We failed to check 1 packages
 

--- a/revdep/README.md
+++ b/revdep/README.md
@@ -1,37 +1,31 @@
 # Platform
 
-|field    |value                                 |
-|:--------|:-------------------------------------|
-|version  |R version 4.4.3 (2025-02-28)          |
-|os       |Ubuntu 24.04.2 LTS                    |
-|system   |x86_64, linux-gnu                     |
-|ui       |RStudio                               |
-|language |en_GB:en                              |
-|collate  |en_GB.UTF-8                           |
-|ctype    |en_GB.UTF-8                           |
-|tz       |Europe/London                         |
-|date     |2025-04-07                            |
-|rstudio  |2024.12.1+563 Kousa Dogwood (desktop) |
-|pandoc   |3.1.3 @ /usr/bin/pandoc               |
-|quarto   |1.6.40 @ /usr/local/bin/quarto        |
+|field    |value                                                                       |
+|:--------|:---------------------------------------------------------------------------|
+|version  |R version 4.5.1 Patched (2025-06-14 r88315)                                 |
+|os       |macOS Sequoia 15.6                                                          |
+|system   |aarch64, darwin20                                                           |
+|ui       |RStudio                                                                     |
+|language |(EN)                                                                        |
+|collate  |en_US.UTF-8                                                                 |
+|ctype    |en_US.UTF-8                                                                 |
+|tz       |Europe/London                                                               |
+|date     |2025-08-19                                                                  |
+|rstudio  |2025.05.0+496 Mariposa Orchid (desktop)                                     |
+|pandoc   |3.7.0.2 @ /usr/local/bin/ (via rmarkdown)                                   |
+|quarto   |1.6.42 @ /Applications/RStudio.app/Contents/Resources/app/quarto/bin/quarto |
 
 # Dependencies
 
-|package |old    |new        |Δ  |
-|:-------|:------|:----------|:--|
-|later   |1.4.1  |1.4.1.9000 |*  |
-|Rcpp    |1.0.14 |1.0.14     |   |
-|rlang   |1.1.5  |1.1.5      |   |
+|package |old   |new        |Δ  |
+|:-------|:-----|:----------|:--|
+|later   |1.4.2 |1.4.2.9000 |*  |
 
 # Revdeps
 
-## Failed to check (5)
+## Failed to check (1)
 
-|package   |version |error |warning |note |
-|:---------|:-------|:-----|:-------|:----|
-|mapview   |?       |      |        |     |
-|OmnipathR |?       |      |        |     |
-|plumber   |?       |      |        |     |
-|Prostar   |?       |      |        |     |
-|tall      |?       |      |        |     |
+|package    |version |error |warning |note |
+|:----------|:-------|:-----|:-------|:----|
+|shinylight |1.2     |1     |        |     |
 

--- a/revdep/cran.md
+++ b/revdep/cran.md
@@ -1,7 +1,12 @@
 ## revdepcheck results
 
-We checked 31 reverse dependencies (26 from CRAN + 5 from Bioconductor), comparing R CMD check results across CRAN and dev versions of this package.
+We checked 33 reverse dependencies (31 from CRAN + 2 from Bioconductor), comparing R CMD check results across CRAN and dev versions of this package.
 
  * We saw 0 new problems
- * We failed to check 0 packages
+ * We failed to check 1 packages
 
+Issues with CRAN packages are summarised below.
+
+### Failed to check
+
+* shinylight (NA)

--- a/revdep/failures.md
+++ b/revdep/failures.md
@@ -1,165 +1,78 @@
-# mapview
+# shinylight
 
 <details>
 
-* Version: 
-* GitHub: https://github.com/r-lib/later
-* Source code: NA
-* Number of recursive dependencies: 0
+* Version: 1.2
+* GitHub: NA
+* Source code: https://github.com/cran/shinylight
+* Date/Publication: 2024-04-23 00:00:10 UTC
+* Number of recursive dependencies: 12
+
+Run `revdepcheck::revdep_details(, "shinylight")` for more info
 
 </details>
 
-## Error before installation
+## In both
+
+*   checking whether package ‘shinylight’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/shikokuchuo/r/later/revdep/checks.noindex/shinylight/new/shinylight.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
 
 ### Devel
 
 ```
-
-
-
-
+* installing *source* package ‘shinylight’ ...
+** this is package ‘shinylight’ version ‘1.2’
+** package ‘shinylight’ successfully unpacked and MD5 sums checked
+** using staged installation
+** R
+** inst
+** byte-compile and prepare package for lazy loading
+Warning in grSoftVersion() :
+  unable to load shared object '/Library/Frameworks/R.framework/Resources/modules//R_X11.so':
+  dlopen(/Library/Frameworks/R.framework/Resources/modules//R_X11.so, 0x0006): Library not loaded: /opt/X11/lib/libSM.6.dylib
+...
+  dlopen(/Library/Frameworks/R.framework/Resources/library/grDevices/libs//cairo.so, 0x0006): Library not loaded: /opt/X11/lib/libXrender.1.dylib
+  Referenced from: <0E3D0D23-EDA1-3578-A817-2824ADD4803C> /Library/Frameworks/R.framework/Versions/4.5-arm64/Resources/library/grDevices/libs/cairo.so
+  Reason: tried: '/opt/X11/lib/libXrender.1.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/opt/X11/lib/libXrender.1.dylib' (no such file), '/opt/X11/lib/libXrender.1.dylib' (no such file), '/Library/Frameworks/R.framework/Resources/lib/libXrender.1.dylib' (no such file), '/Library/Java/JavaVirtualMachines/jdk-11.0.18+10/Contents/Home/lib/server/libXrender.1.dylib' (no such file)
+Warning in grDevices::svg(file = tmp, width = 7, height = 7) :
+  failed to load cairo DLL
+Error in value[[3L]](cond) : unused argument (cond)
+Error: unable to load R code in package ‘shinylight’
+Execution halted
+ERROR: lazy loading failed for package ‘shinylight’
+* removing ‘/Users/shikokuchuo/r/later/revdep/checks.noindex/shinylight/new/shinylight.Rcheck/shinylight’
 
 
 ```
 ### CRAN
 
 ```
-
-
-
-
-
-
-```
-# OmnipathR
-
-<details>
-
-* Version: 
-* GitHub: https://github.com/r-lib/later
-* Source code: NA
-* Number of recursive dependencies: 0
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-
-
-
-
-
-
-```
-### CRAN
-
-```
-
-
-
-
-
-
-```
-# plumber
-
-<details>
-
-* Version: 
-* GitHub: https://github.com/r-lib/later
-* Source code: NA
-* Number of recursive dependencies: 0
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-
-
-
-
-
-
-```
-### CRAN
-
-```
-
-
-
-
-
-
-```
-# Prostar
-
-<details>
-
-* Version: 
-* GitHub: https://github.com/r-lib/later
-* Source code: NA
-* Number of recursive dependencies: 0
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-
-
-
-
-
-
-```
-### CRAN
-
-```
-
-
-
-
-
-
-```
-# tall
-
-<details>
-
-* Version: 
-* GitHub: https://github.com/r-lib/later
-* Source code: NA
-* Number of recursive dependencies: 0
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-
-
-
-
-
-
-```
-### CRAN
-
-```
-
-
-
-
+* installing *source* package ‘shinylight’ ...
+** this is package ‘shinylight’ version ‘1.2’
+** package ‘shinylight’ successfully unpacked and MD5 sums checked
+** using staged installation
+** R
+** inst
+** byte-compile and prepare package for lazy loading
+Warning in grSoftVersion() :
+  unable to load shared object '/Library/Frameworks/R.framework/Resources/modules//R_X11.so':
+  dlopen(/Library/Frameworks/R.framework/Resources/modules//R_X11.so, 0x0006): Library not loaded: /opt/X11/lib/libSM.6.dylib
+...
+  dlopen(/Library/Frameworks/R.framework/Resources/library/grDevices/libs//cairo.so, 0x0006): Library not loaded: /opt/X11/lib/libXrender.1.dylib
+  Referenced from: <0E3D0D23-EDA1-3578-A817-2824ADD4803C> /Library/Frameworks/R.framework/Versions/4.5-arm64/Resources/library/grDevices/libs/cairo.so
+  Reason: tried: '/opt/X11/lib/libXrender.1.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/opt/X11/lib/libXrender.1.dylib' (no such file), '/opt/X11/lib/libXrender.1.dylib' (no such file), '/Library/Frameworks/R.framework/Resources/lib/libXrender.1.dylib' (no such file), '/Library/Java/JavaVirtualMachines/jdk-11.0.18+10/Contents/Home/lib/server/libXrender.1.dylib' (no such file)
+Warning in grDevices::svg(file = tmp, width = 7, height = 7) :
+  failed to load cairo DLL
+Error in value[[3L]](cond) : unused argument (cond)
+Error: unable to load R code in package ‘shinylight’
+Execution halted
+ERROR: lazy loading failed for package ‘shinylight’
+* removing ‘/Users/shikokuchuo/r/later/revdep/checks.noindex/shinylight/old/shinylight.Rcheck/shinylight’
 
 
 ```


### PR DESCRIPTION
Closes #234.

The following benchmarking code suggests a ~8% gain in performance vs. the previous release.

```r
library(later)
start <- Sys.time()
for (i in seq_len(5e6)) {
  later_fd(identity, 21L, timeout = 0L)
  run_now()
}
Sys.time() - start
```