### PR TITLE
Fix timings in tests

### DIFF
--- a/tests/testthat/test-private-loops.R
+++ b/tests/testthat/test-private-loops.R
@@ -460,7 +460,7 @@ test_that("next_op_secs works", {
 
     later(function() {}, 0.1)
     expect_true(next_op_secs() <= 0.1)
-    run_now(0.15)
+    run_now(2)
 
     current_loop()
   })

--- a/tests/testthat/test-run_now.R
+++ b/tests/testthat/test-run_now.R
@@ -146,11 +146,9 @@ test_that("Callbacks cannot affect the caller", {
   # to return from because it (f()) already returned.
   f <- function() {
     delayedAssign("throw", return(100))
-    later(
-      function() {
-        throw
-      }
-    )
+    later(function() {
+      throw
+    })
     return(200)
   }
   g <- function() {

--- a/tests/testthat/test-run_now.R
+++ b/tests/testthat/test-run_now.R
@@ -149,13 +149,12 @@ test_that("Callbacks cannot affect the caller", {
     later(
       function() {
         throw
-      },
-      0.5
+      }
     )
     return(200)
   }
   g <- function() {
-    run_now(1)
+    run_now(2)
   }
   expect_equal(f(), 200)
   expect_snapshot(error = TRUE, g())


### PR DESCRIPTION
Fixes #236.

The failing tests have not been touched for multiple years, nor has code that affect these been changed in this release.
Also we make extensive rhub check runs prior to release (including MKL) e.g. at https://github.com/r-lib/later/actions/runs/17038400115.

I am able to re-produce the series of 3 test failures if and only if the [`run_now()`](https://github.com/r-lib/later/blob/main/tests/testthat/test-run_now.R#L158) in the [`g()` function](https://github.com/r-lib/later/blob/main/tests/testthat/test-run_now.R#L161) fails to execute the prior [`later()` call](https://github.com/r-lib/later/blob/main/tests/testthat/test-run_now.R#L149-L154).
- Reproduce by removing the `0.5` delay in `later()` and commenting out the `run_now()` in `g()`.
- This causes the cascade of subsequent `run_now()` calls to run the previous later call rather than the expected one
- If the initial test actually failed, we would get different error messages for the subsequent errors (if they failed independently themselves)

Although implausible, seems not impossible under extreme load.

The solution is to simply wait a full 2 secs in `g()`.