### PR TITLE
Improve responsiveness when idle at the R console (POSIX systems)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # later (development version)
 
+* Improved responsiveness when idle at the R console on POSIX systems (#251).
+
 * Fixes #249: Moved the contents of `inst/include/later.h` into `later_api.h` to ensure R headers are not included before Rcpp headers when Rcpp auto-includes `$PACKAGE.h` in RcppExports.cpp. The public API header remains `later_api.h` (#250).
 
 # later 1.4.5

--- a/src/later_posix.cpp
+++ b/src/later_posix.cpp
@@ -98,7 +98,8 @@ static void async_input_handler(void *data) {
     // Instead, we set the file descriptor to cold, and tell the timer to fire
     // again in a few milliseconds. This should give enough breathing room that
     // we don't interfere with the sockets too much.
-        timer.set(Timestamp(0.01));
+    // shikokuchuo 2026-02-07: reduced to just one millisecond
+    timer.set(Timestamp(0.001));
     return;
   }
 


### PR DESCRIPTION
From https://github.com/rstudio/shiny/pull/4349, it seems 1ms is generally safe to keep the event loop co-operative. 