### PR TITLE
Fix `once_flag` symbol collision

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # later (development version)
 
+* Fixed #256: compilation failure with glibc >= 2.43 and GCC >= 15, caused by the C11 `once_flag` type now being defined in `<stdlib.h>` under C23. Renamed internal tinycthread symbols to avoid the namespace collision (#257).
+
 # later 1.4.6
 
 * Improved responsiveness when idle at the R console on POSIX systems (#251).

--- a/src/tinycthread.c
+++ b/src/tinycthread.c
@@ -894,7 +894,7 @@ int _tthread_timespec_get(struct timespec *ts, int base)
 #endif /* _TTHREAD_EMULATE_TIMESPEC_GET_ */
 
 #if defined(_TTHREAD_WIN32_)
-void tct_call_once(once_flag *flag, void (*func)(void))
+void tct_call_once(tct_once_flag *flag, void (*func)(void))
 {
   /* The idea here is that we use a spin lock (via the
      InterlockedCompareExchange function) to restrict access to the

--- a/src/tinycthread.h
+++ b/src/tinycthread.h
@@ -465,11 +465,11 @@ int tct_tss_set(tct_tss_t key, void *val);
   typedef struct {
     LONG volatile status;
     CRITICAL_SECTION lock;
-  } once_flag;
-  #define ONCE_FLAG_INIT {0,}
+  } tct_once_flag;
+  #define TCT_ONCE_FLAG_INIT {0,}
 #else
-  #define once_flag pthread_once_t
-  #define ONCE_FLAG_INIT PTHREAD_ONCE_INIT
+  typedef pthread_once_t tct_once_flag;
+  #define TCT_ONCE_FLAG_INIT PTHREAD_ONCE_INIT
 #endif
 
 /** Invoke a callback exactly once
@@ -478,7 +478,7 @@ int tct_tss_set(tct_tss_t key, void *val);
  * @param func Callback to invoke.
  */
 #if defined(_TTHREAD_WIN32_)
-  void tct_call_once(once_flag *flag, void (*func)(void));
+  void tct_call_once(tct_once_flag *flag, void (*func)(void));
 #else
   #define tct_call_once(flag,func) pthread_once(flag,func)
 #endif


### PR DESCRIPTION
Fixes #256.

glibc 2.43 added `once_flag` to `<stdlib.h>` for C23 compliance, and GCC 15 defaults to `-std=gnu23`.

`#define once_flag pthread_once_t` in tinycthread.h turns glibc's
`typedef __once_flag once_flag` into
`typedef __once_flag pthread_once_t`, conflicting with the existing
`typedef int pthread_once_t`.                                                           
                                                                            
Fix: replace the macro with a typedef and rename to `tct_once_flag` / `TCT_ONCE_FLAG_INIT`, consistent with the `tct_` prefix used for all other tinycthread symbols.